### PR TITLE
First version of AWS plugin

### DIFF
--- a/plugins/aws/aws.plugin.sh
+++ b/plugins/aws/aws.plugin.sh
@@ -1,0 +1,20 @@
+# aws.plugin.sh
+# Author: Michael Anckaert <michael.anckaert@sinax.be>
+# Based on oh-my-zsh AWS plugin
+#
+# command 'agp' returns the selected AWS profile (aws get profile)
+# command 'asp' sets the AWS profile to use (aws set profile)
+#
+
+export AWS_HOME=~/.aws
+
+function agp {
+  echo $AWS_DEFAULT_PROFILE
+}
+
+function asp {
+  local rprompt=${RPROMPT/<aws:$(agp)>/}
+
+  export AWS_DEFAULT_PROFILE=$1
+  export AWS_PROFILE=$1
+}


### PR DESCRIPTION
This small plugin makes it easier to work with multiple AWS profiles. It adds two commands (agp and asp) to get and set the current AWS profile. 