### PR TITLE
Only execute oh-my-bash on an interactive shell in .bashrc

### DIFF
--- a/templates/bashrc.osh-template
+++ b/templates/bashrc.osh-template
@@ -49,7 +49,10 @@ OSH_THEME="font"
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(core git bashmarks progress)
 
-source $OSH/oh-my-bash.sh
+if tty -s
+then
+  source $OSH/oh-my-bash.sh
+fi
 
 # User configuration
 


### PR DESCRIPTION
This PR fixes https://github.com/ohmybash/oh-my-bash/issues/18

Oh My Bash should not be executed on noninteractive shells.