### PR TITLE
Add 'bu' function to CD up faster

### DIFF
--- a/plugins/bu/bu.plugin.sh
+++ b/plugins/bu/bu.plugin.sh
@@ -1,0 +1,30 @@
+# bu.plugin.sh
+# Author: Taleeb Midi <taleebmidi@gmail.com>
+# Based on oh-my-zsh AWS plugin
+#
+# command 'bu [N]' Change directory up N times
+#
+
+# Faster Change Directory up
+function bu () {
+  function usage () {
+     cat <<-EOF
+      Usage: bu [N]
+              N        N is the number of level to move back up to, this argument must be a positive integer.
+              h help   displays this basic help menu.
+      EOF
+  }
+  # reset variables
+  STRARGMNT=""
+  FUNCTIONARG=$1
+  # Make sure the provided argument is a positive integer:
+  if [[ ! -z "${FUNCTIONARG##*[!0-9]*}" ]]; then
+    for i in $(seq 1 $FUNCTIONARG); do
+        STRARGMNT+="../"
+    done
+    CMD="cd ${STRARGMNT}"
+    eval $CMD
+  else
+    usage
+  fi
+}


### PR DESCRIPTION
"bu 3" will take the user 3 folders up => cd ../../../
I believe this will add a fast way for users to change directory up and unlike the method used in aliases, this method is not limited to a specific number of predefined aliases.