### PR TITLE
plugins/fasd: Add fasd plugin.

### DIFF
--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -31,6 +31,11 @@ for config_file in $OSH/lib/*.sh; do
   source $config_file
 done
 
+# Load colors first so they can be use in base theme
+source "${OSH}/themes/colours.theme.sh"
+
+# The base theme defines a set of functions that our plugins can use.
+source "${OSH}/themes/base.theme.sh"
 
 is_plugin() {
   local base_dir=$1
@@ -101,9 +106,6 @@ for completion_file in $OSH_CUSTOM/*.sh; do
 done
 unset completion_file
 
-# Load colors first so they can be use in base theme
-source "${OSH}/themes/colours.theme.sh"
-source "${OSH}/themes/base.theme.sh"
 
 # Load the theme
 if [ "$OSH_THEME" = "random" ]; then

--- a/plugins/fasd/fasd.plugin.sh
+++ b/plugins/fasd/fasd.plugin.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+# Initialize fasd, without setting up the prompt hook, which
+# we want to be handled by oh-my-bash.
+
+_fasd_prompt_func() {
+  [ -z "$_FASD_SINK" ] && _FASD_SINK=/dev/null
+  eval "fasd --proc \$(fasd --sanitize \$(history 1 | \\
+    sed "s/^[ ]*[0-9]*[ ]*//"))" >> "$_FASD_SINK" 2>&1
+}
+
+function _install_fasd() {
+  type fasd >/dev/null 2>&1
+  if [ "$?" == "0" ]; then
+    eval "$(fasd --init posix-alias bash-ccomp bash-ccomp-install)"
+    safe_append_prompt_command _fasd_prompt_func
+  else
+    echo "fasd not found, plugin not activated."
+  fi
+}
+
+
+_install_fasd


### PR DESCRIPTION
Fasd offers quick access to files and directories. It
is inspired by tools like autojump, z and v. Fasd keeps track of files
and directories you have accessed, so that you can quickly reference
them in the command line

This plugin sets up fasd to use safe_command_prompt handling
of oh-my-bash to avoid conflicts with fasd's normal bash prompt
handling.

More information about fasd can be found here:
https://github.com/clvv/fasd
.