### PR TITLE
Allow overriding of prompt addition

### DIFF
--- a/themes/base.theme.sh
+++ b/themes/base.theme.sh
@@ -499,6 +499,12 @@ function aws_profile {
   fi
 }
 
+
+# Returns true if $1 is a shell function.
+fn_exists() {
+  type $1 | grep -q 'shell function'
+}
+
 function safe_append_prompt_command {
     local prompt_re
 
@@ -509,6 +515,12 @@ function safe_append_prompt_command {
     else
       # Linux, FreeBSD, etc.
       prompt_re="\<${1}\>"
+    fi
+
+    # See if we need to use the overriden version
+    if [[ $(fn_exists append_prompt_command_override) ]]; then
+       append_prompt_command_override $1
+       return
     fi
 
     if [[ ${PROMPT_COMMAND} =~ ${prompt_re} ]]; then


### PR DESCRIPTION
Some environments have stringent security features that do not allow the
execution of functions inside $PROMPT_COMMAND, breaking every individual
theme.

We now allow the overriding of the prompt setter command to workaround
this.

Example usage:

function append_prompt_command_override() {¶
    pre_prompt_functions+=($1)
}