### PR TITLE
Fix to check bash version before install

### DIFF
--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -134,6 +134,5 @@ if ! type_exists '__git_ps1' ; then
 fi
 
 # Adding Support for other OSes
-PREVIEW="less"
-[ -s /usr/bin/gloobus-preview ] && PREVIEW="gloobus-preview"
-[ -s /Applications/Preview.app ] && PREVIEW="/Applications/Preview.app"
+[ -s /usr/bin/gloobus-preview ] && PREVIEW="gloobus-preview" || 
+[ -s /Applications/Preview.app ] && PREVIEW="/Applications/Preview.app" || PREVIEW="less"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -26,6 +26,17 @@ main() {
   # which may fail on systems lacking tput or terminfo
   set -e
 
+  # Checks the minium version of bash (v4) installed, 
+  # stops the installation if check fails
+  if [ -n $BASH_VERSION ]; then
+     bash_major_version=$(echo $BASH_VERSION | cut -d '.' -f 1)
+     if [ "${bash_major_version}" -lt "4" ]; then
+        printf "Error: Bash 4 required for Oh My Bash.\n"
+        printf "Error: Upgrade Bash and try again.\n"
+        exit 1
+     fi
+  fi
+
   if [ ! -n "$OSH" ]; then
     OSH=$HOME/.oh-my-bash
   fi


### PR DESCRIPTION
Checks the version of bash before installing oh-my-bash. It's a ticky for new users to navigate if they end up in this state and hence a basic check.

See comments here - 
https://github.com/ohmybash/oh-my-bash/issues/27