### PR TITLE
themes/powerline: Fix powerline theme implicitly depends on bash's IFS

### DIFF
--- a/themes/powerline/powerline.base.sh
+++ b/themes/powerline/powerline.base.sh
@@ -148,8 +148,13 @@ function __powerline_prompt_command {
   SEGMENTS_AT_LEFT=0
   LAST_SEGMENT_COLOR=""
 
+  # The IFS (internal field seperator) may have been changed outside to not contain
+  # the space character ' ' whence we need to make sure that the space separated list
+  # stored in POWERLINE_PROMPT is converted into an array correctly.
+  IFS=' ' read -r -a POWERLINE_PROMPT_ARRAY <<< "${POWERLINE_PROMPT}"
+
   ## left prompt ##
-  for segment in $POWERLINE_PROMPT; do
+  for segment in ${POWERLINE_PROMPT_ARRAY[@]}; do
     local info="$(__powerline_${segment}_prompt)"
     [[ -n "${info}" ]] && __powerline_left_segment "${info}"
   done


### PR DESCRIPTION
This PR fixes #36.

The powerline theme implicitly assumes that bash's IFS (internal field seperator) contains a space character. This is used to iterate of the space seperated list stored in `${POWERLINE_PROMPT} `i.e.

```
  for segment in ${POWERLINE_PROMPT}; do
    local info="$(__powerline_${segment}_prompt)"
    [[ -n "${info}" ]] && __powerline_left_segment "${info}"
  done
```
In case any application changes the IFS to not contain a space, instead of a proper powerline bash prompt, one gets the error message `__powerline_user_info scm python_venv cwd_prompt: command not found`

This PR fixes this issue by setting the IFS explicitly when splitting the space seperated string into an array.