### PR TITLE
Add short form of '-g' option to bashmarks plugin

### DIFF
--- a/plugins/bashmarks/README.md
+++ b/plugins/bashmarks/README.md
@@ -14,6 +14,10 @@ You can navigate to the location of a bookmark using the *bm -g* command:
 
 `$ bm -g mydir`
 
+You can also supply just any bookmark name and the *-g* option will be assumed:
+
+`$ bm mydir`
+
 Tab completion is available when you need to enter a bookmark name in a command, such as when using *bm -g*
 
 Easily list all bookmarks you have setup using the *bm -l* command.  
@@ -24,7 +28,7 @@ Easily list all bookmarks you have setup using the *bm -l* command.
 
 **bm -a bookmarkname** Save the current directory as bookmarkname
 
-**bm -g bookmarkname** Go to the specified bookmark
+**bm [-g] bookmarkname** Go to the specified bookmark
 
 **bm -p bookmarkname** Print the bookmark 
 

--- a/plugins/bashmarks/bashmarks.plugin.sh
+++ b/plugins/bashmarks/bashmarks.plugin.sh
@@ -67,17 +67,36 @@ function bm {
       _list_bookmark
     ;;
     # help [ bm -h ]
+    -h)
+      _echo_usage
+    ;;
     *)
-      echo 'USAGE:'
-      echo 'bm -a <bookmark_name> - Saves the current directory as "bookmark_name"'
-      echo 'bm -g <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"'
-      echo 'bm -p <bookmark_name> - Prints the directory associated with "bookmark_name"'
-      echo 'bm -d <bookmark_name> - Deletes the bookmark'
-      echo 'bm -l                 - Lists all available bookmarks'
-      kill -SIGINT $$
-      exit 1
+      if [[ $1 == -* ]]; then
+        # unrecognized option. echo error message and usage [ bm -X ]
+        echo "Unknown option '$1'"
+        _echo_usage
+        kill -SIGINT $$
+        exit 1
+      elif [[ $1 == "" ]]; then
+        # no args supplied - echo usage [ bm ]
+        _echo_usage
+      else
+        # non-option supplied as first arg.  assume goto [ bm BOOKMARK_NAME ]
+        _goto_bookmark "$1"
+      fi
     ;;
   esac
+}
+
+# print usage information
+function _echo_usage {
+  echo 'USAGE:'
+  echo "bm -h                   - Prints this usage info"
+  echo 'bm -a <bookmark_name>   - Saves the current directory as "bookmark_name"'
+  echo 'bm [-g] <bookmark_name> - Goes (cd) to the directory associated with "bookmark_name"'
+  echo 'bm -p <bookmark_name>   - Prints the directory associated with "bookmark_name"'
+  echo 'bm -d <bookmark_name>   - Deletes the bookmark'
+  echo 'bm -l                   - Lists all available bookmarks'
 }
 
 # save current directory to bookmarks


### PR DESCRIPTION
Accept just a bookmark name as a short form of the '-g' option.  If just
  one arg is supplied, and it doesn't start with a dash, then it is assumed
  to be a bookmark name and _goto_bookmark is called. [ bm BOOKMARK_NAME ]
Add a -h option to print usage info with same behavior as supplying no args
Add echoing an error message if an unrecognized option is given, followed
  by usage info
Augment usage info to reflect these changes and update README.md

(this is my first public contribution in a while.  I tried my best to read and follow conventions.)