### PR TITLE
Update wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Most plugins (should! we're working on this) include a __README__, which documen
 
 ### Themes
 
-We'll admit it. Early in the Oh My Bash world, we may have gotten a bit too theme happy. We have over one hundred themes now bundled. Most of them have [screenshots](https://wiki.github.com/ohmybash/oh-my-bash/themes) on the wiki. Check them out!
+We'll admit it. Early in the Oh My Bash world, we may have gotten a bit too theme happy. We have over one hundred themes now bundled. Most of them have [screenshots](https://github.com/robbyrussell/oh-my-zsh/wiki/themes) on the wiki. Check them out!
 
 #### Selecting a Theme
 


### PR DESCRIPTION
The link to the theme previews was dead. This one appears to be the current, proper link.