### PR TITLE
oh-my-bash.sh : Changed the extension on .bash

### DIFF
--- a/oh-my-bash.bash
+++ b/oh-my-bash.bash
@@ -159,5 +159,5 @@ if ! type_exists '__git_ps1' ; then
 fi
 
 # Adding Support for other OSes
-[ -s /usr/bin/gloobus-preview ] && PREVIEW="gloobus-preview" || 
+[ -s /usr/bin/gloobus-preview ] && PREVIEW="gloobus-preview" ||
 [ -s /Applications/Preview.app ] && PREVIEW="/Applications/Preview.app" || PREVIEW="less"


### PR DESCRIPTION
Shabang is set on `#!/usr/bin/env bash`, but file is suffixed with `.sh` which seems not-ideall to me.