### PR TITLE
Remove using of the alias command in theme and appearance.

### DIFF
--- a/lib/theme-and-appearance.sh
+++ b/lib/theme-and-appearance.sh
@@ -2,4 +2,3 @@
 
 # colored ls
 export LSCOLORS='Gxfxcxdxdxegedabagacad'
-alias ls='ls -G'


### PR DESCRIPTION
Setting the color is ok, but the alias should be set on another place.

Refs #106