### PR TITLE
[THEME][POWERLINE] Add possibility to add /n to the end of commands

### DIFF
--- a/themes/powerline/README.md
+++ b/themes/powerline/README.md
@@ -40,6 +40,14 @@ You can change the format using the following variable:
 
 The time/date is printed by the `date` command, so refer to its man page to change the format.
 
+### New Line
+
+You can move the cursor to a new line after each command using the following variable:
+
+    POWERLINE_PROMPT_NEWLINE=true
+
+The prompt will receive a "\n" at the end. This is usefull if you navigate a lot to folders with extensive names.
+
 ### Segment Order
 
 The contents of the prompt can be "reordered", all the "segments" (every piece of information) can take any place. The currently available segments are:

--- a/themes/powerline/powerline.base.sh
+++ b/themes/powerline/powerline.base.sh
@@ -2,6 +2,7 @@
 
 # Define this here so it can be used by all of the Powerline themes
 THEME_CHECK_SUDO=${THEME_CHECK_SUDO:=true}
+POWERLINE_PROMPT_NEWLINE=${POWERLINE_PROMPT_NEWLINE:=false}
 
 function set_color {
   if [[ "${1}" != "-" ]]; then
@@ -155,8 +156,9 @@ function __powerline_prompt_command {
   done
   [[ "${last_status}" -ne 0 ]] && __powerline_left_segment $(__powerline_last_status_prompt ${last_status})
   [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(set_color ${LAST_SEGMENT_COLOR} -)${separator_char}${normal}"
+  [[ "${POWERLINE_PROMPT_NEWLINE=}" == true ]] && END_PROMPT=" \n" || END_PROMPT=""
 
-  PS1="${LEFT_PROMPT} "
+  PS1="${LEFT_PROMPT}${END_PROMPT}"
 
   ## cleanup ##
   unset LAST_SEGMENT_COLOR \


### PR DESCRIPTION
You can move the cursor to a new line after each command using the following variable:

    POWERLINE_PROMPT_NEWLINE=true

The prompt will receive a "\n" at the end. This is usefull if you navigate a lot to folders with extensive names.