### PR TITLE
A better progress bar

### DIFF
--- a/plugins/progress/README.md
+++ b/plugins/progress/README.md
@@ -1,0 +1,2 @@
+# Easy to use progress bar
+

--- a/plugins/progress/README.md
+++ b/plugins/progress/README.md
@@ -1,2 +1,24 @@
-# Easy to use progress bar
+# progress2
+
+Spice up your scripts with a full width animated progress bar which also adjusts to window size changes.
+
+## Usage
+
+```shell
+source $OSH/plugins/progress/progress2.plugin.sh
+
+init_progress
+progress 1
+...
+progress 10
+...
+progress 90
+...
+progress 100
+```
+
+## Advanced
+
+The characters used to draw the progress bar can be changed to suit your tastes. Simply set your own values (see script for complete list) after calling init_progress but before calling progress for the first time.
+
 

--- a/plugins/progress/example.sh
+++ b/plugins/progress/example.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source $OSH/plugins/progress/progress2.plugin.sh
+
+for i in {0..101}; do progress $i; done

--- a/plugins/progress/progress.plugin.sh
+++ b/plugins/progress/progress.plugin.sh
@@ -1,21 +1,16 @@
 #!/usr/bin/env bash
-############################---Description---###################################
-#                                                                              #
-# Summary       : Show a progress bar GUI on terminal platform                 #
-# Support       : destro.nnt@gmail.com                                         #
-# Created date  : Aug 12,2014                                                  #
-# Latest Modified date : Aug 13,2014                                           #
-#                                                                              #
-################################################################################
+#Description:
 
-############################---Usage---#########################################
+# Summary       : Show a progress bar GUI on terminal platform
+# Support       : destro.nnt@gmail.com
+# Created date  : Aug 12,2014
+# Last Modified : Feb, 21, 2020
+# Last Modifier : FG Robertson (https://github.com/grobertson)                 
 
-# Copy below functions (delay and progress fuctions) into your shell script directly
-# Then invoke progress function to show progress bar 
 
-# In other way, you could import source indirectly then using. Nothing different
-
-################################################################################
+#Usage:
+# source into your script.
+# progress int n(1...100) string<"Phase">
 
 
 #
@@ -33,7 +28,7 @@ CURRENT_PROGRESS=0
 function progress()
 {
     PARAM_PROGRESS=$1;
-    PARAM_STATUS=$2;
+    PARAM_PHASE=$2;
 
     if [ $CURRENT_PROGRESS -le 0 -a $PARAM_PROGRESS -ge 0 ]  ; then echo -ne "[..........................] (0%)  $PARAM_PHASE \r"  ; delay; fi;
     if [ $CURRENT_PROGRESS -le 5 -a $PARAM_PROGRESS -ge 5 ]  ; then echo -ne "[#.........................] (5%)  $PARAM_PHASE \r"  ; delay; fi;

--- a/plugins/progress/progress2.plugin.sh
+++ b/plugins/progress/progress2.plugin.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020, F. Grant Robertson, https://github.com/grobertson/
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided
+# that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice, this list of conditions
+#       and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#       following disclaimer in the documentation and/or other materials provided with the distribution.
+#     * Neither the name of F. Grant Robertson (aka @grobertson) nor the names of contributors
+#       may be used to endorse or promote products derived from this software without
+#       specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Intended to improve upon progress.plugin.sh by destro.nnt@gmail.com, Aug 13,2014. YMMV. 
+
+# USAGE:
+
+# source into your script. Call the progress function to update the ui.
+
+_STEP_DELAY=0.1;
+shopt -s checkwinsize; (:); #echo $LINES $COLUMNS
+
+#
+# Description : delay between steps
+#
+function delay
+{
+    sleep $_STEP_DELAY;
+}
+
+#
+# Description : set the delay interval
+function set_delay()
+{
+    $_STEP_DELAY=$1
+}
+
+#
+# Description : print out executing progress
+# 
+_PCT_THEN=0
+function progress()
+{
+    _PCT_NOW=$1;
+    _PARAM_PHASE=$2;
+    #TODO: find/use width of term
+    if [ $_PCT_THEN -le 0 ] && [ $_PCT_NOW -ge 0 ]  ; then echo -ne "[..........................] (0%)  $PARAM_PHASE \r"  ; delay; fi;
+    if [ $_PCT_THEN -le 90 ] && [ $_PCT_NOW -ge 90 ]; then echo -ne "[##########################] (100%) $PARAM_PHASE \r" ; delay; fi;
+    if [ $_PCT_THEN -le 100 ] && [ $_PCT_NOW -ge 100 ];then echo -ne 'Done!                                            \n' ; delay; fi;
+
+    _PCT_THEN=$_PCT_NOW;
+}

--- a/plugins/progress/progress2.plugin.sh
+++ b/plugins/progress/progress2.plugin.sh
@@ -27,7 +27,7 @@
 
 # USAGE:
 
-See README.md
+# See README.md
 
 #
 # Description: Called automatically if _REMAIN_CHAR is unset


### PR DESCRIPTION
Fixed a bug in the existing progress bar plugin where "phase" was misnamed.

Then I couldn't leave well enough alone so I wrote a much better version.

I left the original version with my fix, and named my rewrite progress2. I wasn't sure about just rm'ing it, but my version is backwards compatible with the existing plugin.

To try it out, first source the progress2.plugin.sh script. Then just ...

`for i in {0..101}; do progress $i; done`
