### PR TITLE
aliases/general: Add fix_term alias to reset the terminal

### DIFF
--- a/aliases/general.aliases.sh
+++ b/aliases/general.aliases.sh
@@ -26,5 +26,6 @@ alias c='clear'                             # c:            Clear terminal displ
 alias path='echo -e ${PATH//:/\\n}'         # path:         Echo all executable Paths
 alias show_options='shopt'                  # Show_options: display bash options settings
 alias fix_stty='stty sane'                  # fix_stty:     Restore terminal settings when screwed up
+alias fix_term='echo -e "\033c"'            # fix_term:     Reset the conosle.  Similar to the reset command
 alias cic='set completion-ignore-case On'   # cic:          Make tab-completion case-insensitive
 alias src='source ~/.bashrc'                # src:          Reload .bashrc file


### PR DESCRIPTION
- This alias resets the terminal in cases where `stty sane` and reset may not work.  From [wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code): 

> This will reset the console, similar to the command reset on modern Linux systems; however it should work even on older Linux systems and on other (non-Linux) UNIX variants.