### PR TITLE
lib, themes: Preserve users' PROMPT_DIRTRIM

### DIFF
--- a/lib/shopt.sh
+++ b/lib/shopt.sh
@@ -12,7 +12,7 @@ set -o noclobber
 shopt -s checkwinsize
 
 # Automatically trim long paths in the prompt (requires Bash 4.x)
-PROMPT_DIRTRIM=2
+PROMPT_DIRTRIM=${PROMPT_DIRTRIM:-2}
 
 # Enable history expansion with space
 # E.g. typing !!<space> will replace the !! with your last command

--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -135,7 +135,7 @@
 
 # note: requires bash v4+... Mac users - you often have bash3.
 # 'brew install bash' will set you free
-PROMPT_DIRTRIM=2 # bash4 and above
+PROMPT_DIRTRIM=${PROMPT_DIRTRIM:-2} # bash4 and above
 
 ######################################################################
 ## Configurations in Oh My Bash

--- a/themes/roderik/roderik.theme.sh
+++ b/themes/roderik/roderik.theme.sh
@@ -4,7 +4,7 @@ export GIT_PS1_SHOWDIRTYSTATE=true
 export GIT_PS1_SHOWUNTRACKEDFILES=true
 export GIT_PS1_SHOWSTASHSTATE=true
 
-export PROMPT_DIRTRIM=3
+export PROMPT_DIRTRIM=${PROMPT_DIRTRIM:-3}
 
 function _omb_theme_PROMPT_COMMAND() {
     if [[ ${EUID} == 0 ]] ; then

--- a/themes/vscode/vscode.theme.sh
+++ b/themes/vscode/vscode.theme.sh
@@ -38,4 +38,4 @@ function _omb_theme_vscode_initialize {
 _omb_theme_vscode_initialize
 
 function _omb_theme_PROMPT_COMMAND { true; }
-PROMPT_DIRTRIM=4
+PROMPT_DIRTRIM=${PROMPT_DIRTRIM:-4}


### PR DESCRIPTION
This change will allow a user to export the PROMPT_DIRTRIM variable in
their .bashrc and change the prompt path length.