### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ If you have any hiccups installing, here are a few common fixes.
 
 * You _might_ need to modify your `PATH` in `~/.bashrc` if you're not able to find some commands after switching to `oh-my-bash`.
 * If you installed manually or changed the install location, check the `OSH` environment variable in `~/.bashrc`.
+* You _might_ need to [install Oh My Bash](#basic-installation) with `$ bash` instead of `$ sh`.
 
 ### Custom Plugins and Themes
 


### PR DESCRIPTION
The issue is still present for mac users.
```
bash-5.0$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)"
Error: Bash 4 required for Oh My Bash.
Error: Upgrade Bash and try again.
```
Since the issue appears to be relatively common, it might be wise to point to it in the readme file.