### PR TITLE
lib/grep.sh: fix expansion of GREP_OPTIONS

### DIFF
--- a/lib/grep.sh
+++ b/lib/grep.sh
@@ -4,24 +4,24 @@ grep_flag_available() {
     echo | grep $1 "" >/dev/null 2>&1
 }
 
-GREP_OPTIONS=""
+GREP_OPTIONS=()
 
 # color grep results
 if grep_flag_available --color=auto; then
-    GREP_OPTIONS+=( " --color=auto" )
+    GREP_OPTIONS+=( "--color=auto" )
 fi
 
 # ignore VCS folders (if the necessary grep flags are available)
 VCS_FOLDERS="{.bzr,CVS,.git,.hg,.svn}"
 
 if grep_flag_available --exclude-dir=.cvs; then
-    GREP_OPTIONS+=( " --exclude-dir=$VCS_FOLDERS" )
+    GREP_OPTIONS+=( "--exclude-dir=$VCS_FOLDERS" )
 elif grep_flag_available --exclude=.cvs; then
-    GREP_OPTIONS+=( " --exclude=$VCS_FOLDERS" )
+    GREP_OPTIONS+=( "--exclude=$VCS_FOLDERS" )
 fi
 
 # export grep settings
-alias grep="grep $GREP_OPTIONS"
+alias grep="grep ${GREP_OPTIONS[*]}"
 
 # clean up
 unset GREP_OPTIONS


### PR DESCRIPTION
Previously, only the first element of the array was expanded, which is
always the empty string, so the setting of GREP_OPTIONS was useless. Expand
the entire array.