### PR TITLE
lib/utils: Include functions when searching for a command

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -161,7 +161,13 @@ is_confirmed() {
 }
 
 #
-# Test whether a command exists
+# Test whether a command is defined. Includes:
+#   alias (command is shell alias)
+#   keyword (command is shell reserved word)
+#   function (command is shell function)
+#   builtin (command is shell builtin)
+#   file (command is disk file)
+#
 # $1 = cmd to test
 # Usage:
 # if type_exists 'git'; then
@@ -171,7 +177,7 @@ is_confirmed() {
 # fi
 #
 type_exists() {
-  [ "$(type -P "$1")" ]
+  [ "$(type -t "$1")" ]
 }
 
 #

--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -154,7 +154,7 @@ if [[ $PROMPT ]]; then
     export PS1="\["$PROMPT"\]"
 fi
 
-if ! type_exists '__git_ps1' ; then
+if ! _omb_util_command_exists '__git_ps1' ; then
   source "$OSH/tools/git-prompt.sh"
 fi
 

--- a/plugins/sdkman/sdkman.plugin.sh
+++ b/plugins/sdkman/sdkman.plugin.sh
@@ -4,6 +4,6 @@
 [[ ${SDKMAN_DIR-} ]] || export SDKMAN_DIR=~/.sdkman
 
 # Try to load sdk only if the command is not available
-if ! type_exists sdk && [[ -s $SDKMAN_DIR/bin/sdkman-init.sh ]]; then
+if ! _omb_util_command_exists sdk && [[ -s $SDKMAN_DIR/bin/sdkman-init.sh ]]; then
   source "$SDKMAN_DIR/bin/sdkman-init.sh"
 fi

--- a/plugins/zoxide/zoxide.plugin.sh
+++ b/plugins/zoxide/zoxide.plugin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check if zoxide is installed
-if type_exists zoxide; then
+if _omb_util_command_exists zoxide; then
     eval "$(zoxide init bash)"
 else
     echo '[oh-my-bash] zoxide not found, please install it from https://github.com/ajeetdsouza/zoxide'

--- a/themes/base.theme.sh
+++ b/themes/base.theme.sh
@@ -516,7 +516,7 @@ function battery_char {
     fi
 }
 
-if ! type_exists 'battery_charge' ; then
+if ! _omb_util_command_exists 'battery_charge' ; then
     # if user has installed battery plugin, skip this...
     function battery_charge (){
         # no op
@@ -526,7 +526,7 @@ fi
 
 # The battery_char function depends on the presence of the battery_percentage function.
 # If battery_percentage is not defined, then define battery_char as a no-op.
-if ! type_exists 'battery_percentage' ; then
+if ! _omb_util_command_exists 'battery_percentage' ; then
     function battery_char (){
       # no op
       echo -n

--- a/themes/powerline/powerline.base.sh
+++ b/themes/powerline/powerline.base.sh
@@ -43,9 +43,9 @@ function __powerline_user_info_prompt {
 function __powerline_ruby_prompt {
   local ruby_version=""
 
-  if type_exists 'rvm'; then
+  if _omb_util_command_exists 'rvm'; then
     ruby_version="$(rvm_version_prompt)"
-  elif type_exists 'rbenv'; then
+  elif _omb_util_command_exists 'rbenv'; then
     ruby_version=$(rbenv_version_prompt)
   fi
 


### PR DESCRIPTION
The original function `type_exists` uses the option `-P` that limits the scope of the search to commands defined by files.

When debugging why the battery plugin was not working, I figured out that, also when the plugin was loaded, the function was overwritten by:

```
if ! type_exists 'battery_charge' ; then
    # if user has installed battery plugin, skip this...
    function battery_charge (){
        # no op
        echo -n
    }
fi
```

The issue is that`battery_charge` is defined as a function in the `battery` plugin and `type_exists` return `false`.

This PR expands the search scope (via the `-t` option) to:
-   alias (command is shell alias)
-   keyword (command is shell reserved word)
-   function (command is shell function)
-   builtin (command is shell builtin)
-   file (command is disk file)
