### PR TITLE
base.theme.sh: use “command” to run git and svn everywhere

### DIFF
--- a/completions/svn.completion.sh
+++ b/completions/svn.completion.sh
@@ -79,7 +79,7 @@ function _svn_grcut()
 function _svn_info()
 {
   local what=$1 line=
-  LANG=C LC_MESSAGES=C svn info --non-interactive 2> /dev/null | \
+  LANG=C LC_MESSAGES=C command svn info --non-interactive 2> /dev/null | \
   while read line ; do
     [[ $line == *"$what: "* ]] && echo ${line#*: }
   done
@@ -689,7 +689,7 @@ _svn()
 
 		# build status command and options
 		# "--quiet" removes 'unknown' files
-		local status='svn status --non-interactive'
+		local status='command svn status --non-interactive'
 
 		[[ $SVN_BASH_COMPL_EXT == *recurse* ]] || \
 		    status="$status --non-recursive"

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -82,7 +82,7 @@ function git_current_branch() {
 # Gets the number of commits ahead from remote
 function git_commits_ahead() {
   if command git rev-parse --git-dir &>/dev/null; then
-    local commits="$(git rev-list --count @{upstream}..HEAD)"
+    local commits="$(command git rev-list --count @{upstream}..HEAD)"
     if [[ "$commits" != 0 ]]; then
       echo "$OSH_THEME_GIT_COMMITS_AHEAD_PREFIX$commits$OSH_THEME_GIT_COMMITS_AHEAD_SUFFIX"
     fi
@@ -92,7 +92,7 @@ function git_commits_ahead() {
 # Gets the number of commits behind remote
 function git_commits_behind() {
   if command git rev-parse --git-dir &>/dev/null; then
-    local commits="$(git rev-list --count HEAD..@{upstream})"
+    local commits="$(command git rev-list --count HEAD..@{upstream})"
     if [[ "$commits" != 0 ]]; then
       echo "$OSH_THEME_GIT_COMMITS_BEHIND_PREFIX$commits$OSH_THEME_GIT_COMMITS_BEHIND_SUFFIX"
     fi

--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -329,8 +329,8 @@ function svn_prompt_vars {
   fi
   SCM_PREFIX=${SVN_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
   SCM_SUFFIX=${SVN_THEME_PROMPT_SUFFIX:-$SCM_THEME_PROMPT_SUFFIX}
-  SCM_BRANCH=$(svn info 2> /dev/null | awk -F/ '/^URL:/ { for (i=0; i<=NF; i++) { if ($i == "branches" || $i == "tags" ) { print $(i+1); break }; if ($i == "trunk") { print $i; break } } }') || return
-  SCM_CHANGE=$(svn info 2> /dev/null | sed -ne 's#^Revision: ##p' )
+  SCM_BRANCH=$(command svn info 2> /dev/null | awk -F/ '/^URL:/ { for (i=0; i<=NF; i++) { if ($i == "branches" || $i == "tags" ) { print $(i+1); break }; if ($i == "trunk") { print $i; break } } }') || return
+  SCM_CHANGE=$(command svn info 2> /dev/null | sed -ne 's#^Revision: ##p' )
 }
 
 # this functions returns absolute location of .hg directory if one exists

--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -106,9 +106,9 @@ function _omb_prompt_format {
 function scm {
   if [[ "$SCM_CHECK" = false ]]; then SCM=$SCM_NONE
   elif [[ -f .git/HEAD ]]; then SCM=$SCM_GIT
-  elif _omb_util_binary_exists git && [[ -n "$(git rev-parse --is-inside-work-tree 2> /dev/null)" ]]; then SCM=$SCM_GIT
+  elif _omb_util_binary_exists git && [[ -n "$(command git rev-parse --is-inside-work-tree 2> /dev/null)" ]]; then SCM=$SCM_GIT
   elif [[ -d .hg ]]; then SCM=$SCM_HG
-  elif _omb_util_binary_exists hg && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
+  elif _omb_util_binary_exists hg && [[ -n "$(command hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
   elif [[ -d .svn ]]; then SCM=$SCM_SVN
   else SCM=$SCM_NONE
   fi
@@ -238,10 +238,10 @@ function git_prompt_vars {
   local details=''
   local git_status_flags=''
   SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
-  if [[ "$(git config --get bash-it.hide-status)" != "1" ]]; then
+  if [[ "$(command git config --get bash-it.hide-status)" != "1" ]]; then
     [[ "${SCM_GIT_IGNORE_UNTRACKED}" = "true" ]] && git_status_flags='-uno'
-    local status_lines=$((git status --porcelain ${git_status_flags} -b 2> /dev/null ||
-                          git status --porcelain ${git_status_flags}    2> /dev/null) | git_status_summary)
+    local status_lines=$((command git status --porcelain ${git_status_flags} -b 2> /dev/null ||
+                          command git status --porcelain ${git_status_flags}    2> /dev/null) | git_status_summary)
     local status=$(awk 'NR==1' <<< "$status_lines")
     local counts=$(awk 'NR==2' <<< "$status_lines")
     IFS=$'\t' read untracked_count unstaged_count staged_count <<< "$counts"
@@ -258,7 +258,7 @@ function git_prompt_vars {
 
   [[ "${SCM_GIT_SHOW_CURRENT_USER}" == "true" ]] && details+="$(git_user_info)"
 
-  SCM_CHANGE=$(git rev-parse --short HEAD 2>/dev/null)
+  SCM_CHANGE=$(command git rev-parse --short HEAD 2>/dev/null)
 
   local ref=$(git_clean_branch)
 
@@ -272,7 +272,7 @@ function git_prompt_vars {
       local remote_name=${tracking_info%%/*}
       local remote_branch=${tracking_info#${remote_name}/}
       local remote_info=""
-      local num_remotes=$(git remote | wc -l 2> /dev/null)
+      local num_remotes=$(command git remote | wc -l 2> /dev/null)
       [[ "${SCM_BRANCH}" = "${remote_branch}" ]] && local same_branch_name=true
       if ([[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "auto" ]] && [[ "${num_remotes}" -ge 2 ]]) ||
           [[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "true" ]]; then
@@ -292,11 +292,11 @@ function git_prompt_vars {
     SCM_GIT_DETACHED="false"
   else
     local detached_prefix=""
-    ref=$(git describe --tags --exact-match 2> /dev/null)
+    ref=$(command git describe --tags --exact-match 2> /dev/null)
     if [[ -n "$ref" ]]; then
       detached_prefix=${SCM_THEME_TAG_PREFIX}
     else
-      ref=$(git describe --contains --all HEAD 2> /dev/null)
+      ref=$(command git describe --contains --all HEAD 2> /dev/null)
       ref=${ref#remotes/}
       [[ -z "$ref" ]] && ref=${SCM_CHANGE}
       detached_prefix=${SCM_THEME_DETACHED_PREFIX}
@@ -310,7 +310,7 @@ function git_prompt_vars {
   [[ "${status}" =~ ${ahead_re} ]] && SCM_BRANCH+=" ${SCM_GIT_AHEAD_CHAR}${BASH_REMATCH[1]}"
   [[ "${status}" =~ ${behind_re} ]] && SCM_BRANCH+=" ${SCM_GIT_BEHIND_CHAR}${BASH_REMATCH[1]}"
 
-  local stash_count="$(git stash list 2> /dev/null | wc -l | tr -d ' ')"
+  local stash_count="$(command git stash list 2> /dev/null | wc -l | tr -d ' ')"
   [[ "${stash_count}" -gt 0 ]] && SCM_BRANCH+=" {${stash_count}}"
 
   SCM_BRANCH+=${details}
@@ -320,7 +320,7 @@ function git_prompt_vars {
 }
 
 function svn_prompt_vars {
-  if [[ -n $(svn status 2> /dev/null) ]]; then
+  if [[ -n $(command svn status 2> /dev/null) ]]; then
     SCM_DIRTY=1
     SCM_STATE=${SVN_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
   else
@@ -505,9 +505,9 @@ _omb_deprecate_function 20000 python_version_prompt _omb_prompt_print_python_env
 
 function git_user_info {
   # support two or more initials, set by 'git pair' plugin
-  SCM_CURRENT_USER=$(git config user.initials | sed 's% %+%')
+  SCM_CURRENT_USER=$(command git config user.initials | sed 's% %+%')
   # if `user.initials` weren't set, attempt to extract initials from `user.name`
-  [[ -z "${SCM_CURRENT_USER}" ]] && SCM_CURRENT_USER=$(printf "%s" $(for word in $(git config user.name | tr 'A-Z' 'a-z'); do printf "%1.1s" $word; done))
+  [[ -z "${SCM_CURRENT_USER}" ]] && SCM_CURRENT_USER=$(printf "%s" $(for word in $(command git config user.name | tr 'A-Z' 'a-z'); do printf "%1.1s" $word; done))
   [[ -n "${SCM_CURRENT_USER}" ]] && printf "%s" "$SCM_THEME_CURRENT_USER_PREFFIX$SCM_CURRENT_USER$SCM_THEME_CURRENT_USER_SUFFIX"
 }
 

--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -354,7 +354,7 @@ function get_hg_root {
 }
 
 function hg_prompt_vars {
-    if [[ -n $(hg status 2> /dev/null) ]]; then
+    if [[ -n $(command hg status 2> /dev/null) ]]; then
       SCM_DIRTY=1
         SCM_STATE=${HG_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
     else
@@ -370,14 +370,14 @@ function hg_prompt_vars {
         # Mercurial holds it's current branch in .hg/branch file
         SCM_BRANCH=$(cat "$HG_ROOT/branch")
     else
-        SCM_BRANCH=$(hg summary 2> /dev/null | grep branch: | awk '{print $2}')
+        SCM_BRANCH=$(command hg summary 2> /dev/null | grep branch: | awk '{print $2}')
     fi
 
     if [ -f "$HG_ROOT/dirstate" ]; then
         # Mercurial holds various information about the working directory in .hg/dirstate file. More on http://mercurial.selenic.com/wiki/DirState
         SCM_CHANGE=$(hexdump -n 10 -e '1/1 "%02x"' "$HG_ROOT/dirstate" | cut -c-12)
     else
-        SCM_CHANGE=$(hg summary 2> /dev/null | grep parent: | awk '{print $2}')
+        SCM_CHANGE=$(command hg summary 2> /dev/null | grep parent: | awk '{print $2}')
     fi
 }
 

--- a/plugins/git/git.plugin.sh
+++ b/plugins/git/git.plugin.sh
@@ -35,98 +35,98 @@ function work_in_progress() {
 # (sorted alphabetically)
 #
 
-alias g='git'
+alias g='command git'
 
-alias ga='git add'
-alias gaa='git add --all'
-alias gapa='git add --patch'
-alias gau='git add --update'
+alias ga='command git add'
+alias gaa='command git add --all'
+alias gapa='command git add --patch'
+alias gau='command git add --update'
 
-alias gb='git branch'
-alias gba='git branch -a'
-alias gbd='git branch -d'
-alias gbD='git branch --delete --force'
-alias gbda='git branch --no-color --merged | command grep -vE "^(\*|\s*(master|develop|dev)\s*$)" | command xargs -n 1 git branch -d'
-alias gbl='git blame -b -w'
-alias gbnm='git branch --no-merged'
-alias gbr='git branch --remote'
-alias gbs='git bisect'
-alias gbsb='git bisect bad'
-alias gbsg='git bisect good'
-alias gbsr='git bisect reset'
-alias gbss='git bisect start'
+alias gb='command git branch'
+alias gba='command git branch -a'
+alias gbd='command git branch -d'
+alias gbD='command git branch --delete --force'
+alias gbda='command git branch --no-color --merged | command grep -vE "^(\*|\s*(master|develop|dev)\s*$)" | command xargs -n 1 git branch -d'
+alias gbl='command git blame -b -w'
+alias gbnm='command git branch --no-merged'
+alias gbr='command git branch --remote'
+alias gbs='command git bisect'
+alias gbsb='command git bisect bad'
+alias gbsg='command git bisect good'
+alias gbsr='command git bisect reset'
+alias gbss='command git bisect start'
 
-alias gc='git commit -v'
-alias gc!='git commit -v --amend'
-alias gcn!='git commit -v --no-edit --amend'
-alias gca='git commit -v -a'
-alias gca!='git commit -v -a --amend'
-alias gcan!='git commit -v -a --no-edit --amend'
-alias gcans!='git commit -v -a -s --no-edit --amend'
-alias gcam='git commit -a -m'
-alias gcsm='git commit -s -m'
-alias gcb='git checkout -b'
-alias gcf='git config --list'
-alias gcl='git clone --recursive'
-alias gclean='git clean -fd'
-alias gpristine='git reset --hard && git clean -dfx'
-alias gcm='git checkout master'
-alias gcd='git checkout develop'
-alias gcmsg='git commit -m'
-alias gco='git checkout'
-alias gcount='git shortlog -sn'
+alias gc='command git commit -v'
+alias gc!='command git commit -v --amend'
+alias gcn!='command git commit -v --no-edit --amend'
+alias gca='command git commit -v -a'
+alias gca!='command git commit -v -a --amend'
+alias gcan!='command git commit -v -a --no-edit --amend'
+alias gcans!='command git commit -v -a -s --no-edit --amend'
+alias gcam='command git commit -a -m'
+alias gcsm='command git commit -s -m'
+alias gcb='command git checkout -b'
+alias gcf='command git config --list'
+alias gcl='command git clone --recursive'
+alias gclean='command git clean -fd'
+alias gpristine='command git reset --hard && git clean -dfx'
+alias gcm='command git checkout master'
+alias gcd='command git checkout develop'
+alias gcmsg='command git commit -m'
+alias gco='command git checkout'
+alias gcount='command git shortlog -sn'
 #compdef _git gcount complete -F _git gcount
-alias gcp='git cherry-pick'
-alias gcpa='git cherry-pick --abort'
-alias gcpc='git cherry-pick --continue'
-alias gcps='git cherry-pick -s'
-alias gcs='git commit -S'
+alias gcp='command git cherry-pick'
+alias gcpa='command git cherry-pick --abort'
+alias gcpc='command git cherry-pick --continue'
+alias gcps='command git cherry-pick -s'
+alias gcs='command git commit -S'
 
-alias gd='git diff'
-alias gdca='git diff --cached'
-alias gdct='git describe --tags `git rev-list --tags --max-count=1`'
-alias gdt='git diff-tree --no-commit-id --name-only -r'
-alias gdw='git diff --word-diff'
+alias gd='command git diff'
+alias gdca='command git diff --cached'
+alias gdct='command git describe --tags `git rev-list --tags --max-count=1`'
+alias gdt='command git diff-tree --no-commit-id --name-only -r'
+alias gdw='command git diff --word-diff'
 
 function gdv {
-  git diff -w "$@" | view -
+  command git diff -w "$@" | view -
 }
 #compdef _git gdv=git-diff
 
-alias gf='git fetch'
-alias gfa='git fetch --all --prune'
-alias gfo='git fetch origin'
+alias gf='command git fetch'
+alias gfa='command git fetch --all --prune'
+alias gfo='command git fetch origin'
 
 function gfg {
-  git ls-files | grep "$@"
+  command git ls-files | grep "$@"
 }
 #compdef _grep gfg
 
-alias gg='git gui citool'
-alias gga='git gui citool --amend'
+alias gg='command git gui citool'
+alias gga='command git gui citool --amend'
 
 function ggf {
   [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git push --force origin "${b:=$1}"
+  command git push --force origin "${b:=$1}"
 }
 #compdef _git ggf=git-checkout
 
 function ggl {
   if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
-    git pull origin "${*}"
+    command git pull origin "${*}"
   else
     [[ "$#" == 0 ]] && local b="$(git_current_branch)"
-    git pull origin "${b:=$1}"
+    command git pull origin "${b:=$1}"
   fi
 }
 #compdef _git ggl=git-checkout
 
 function ggp {
   if [[ "$#" != 0 ]] && [[ "$#" != 1 ]]; then
-    git push origin "${*}"
+    command git push origin "${*}"
   else
     [[ "$#" == 0 ]] && local b="$(git_current_branch)"
-    git push origin "${b:=$1}"
+    command git push origin "${b:=$1}"
   fi
 }
 #compdef _git ggp=git-checkout
@@ -142,105 +142,105 @@ function ggpnp {
 
 function ggu {
   [[ "$#" != 1 ]] && local b="$(git_current_branch)"
-  git pull --rebase origin "${b:=$1}"
+  command git pull --rebase origin "${b:=$1}"
 }
 #compdef _git ggu=git-checkout
 
 alias ggpur='ggu'
 #compdef _git ggpur=git-checkout
 
-alias ggpull='git pull origin $(git_current_branch)'
+alias ggpull='command git pull origin $(git_current_branch)'
 #compdef _git ggpull=git-checkout
 
-alias ggpush='git push origin $(git_current_branch)'
+alias ggpush='command git push origin $(git_current_branch)'
 #compdef _git ggpush=git-checkout
 
-alias ggsup='git branch --set-upstream-to=origin/$(git_current_branch)'
-alias gpsup='git push --set-upstream origin $(git_current_branch)'
+alias ggsup='command git branch --set-upstream-to=origin/$(git_current_branch)'
+alias gpsup='command git push --set-upstream origin $(git_current_branch)'
 
-alias ghh='git help'
+alias ghh='command git help'
 
-alias gignore='git update-index --assume-unchanged'
-alias gignored='git ls-files -v | grep "^[[:lower:]]"'
-alias git-svn-dcommit-push='git svn dcommit && git push github master:svntrunk'
+alias gignore='command git update-index --assume-unchanged'
+alias gignored='command git ls-files -v | grep "^[[:lower:]]"'
+alias git-svn-dcommit-push='command git svn dcommit && git push github master:svntrunk'
 #compdef _git git-svn-dcommit-push=git
 
 alias gk='\gitk --all --branches'
-#compdef _git gk='gitk'
+#compdef _git gk='command gitk'
 alias gke='\gitk --all $(git log -g --pretty=%h)'
-#compdef _git gke='gitk'
+#compdef _git gke='command gitk'
 
-alias gl='git pull'
-alias glg='git log --stat'
-alias glgp='git log --stat -p'
-alias glgg='git log --graph'
-alias glgga='git log --graph --decorate --all'
-alias glgm='git log --graph --max-count=10'
-alias glo='git log --oneline --decorate'
-alias glol="git log --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
-alias glola="git log --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all"
-alias glog='git log --oneline --decorate --graph'
-alias gloga='git log --oneline --decorate --graph --all'
+alias gl='command git pull'
+alias glg='command git log --stat'
+alias glgp='command git log --stat -p'
+alias glgg='command git log --graph'
+alias glgga='command git log --graph --decorate --all'
+alias glgm='command git log --graph --max-count=10'
+alias glo='command git log --oneline --decorate'
+alias glol="command git log --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
+alias glola="command git log --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all"
+alias glog='command git log --oneline --decorate --graph'
+alias gloga='command git log --oneline --decorate --graph --all'
 alias glp="_git_log_prettily"
 #compdef _git glp=git-log
 
-alias gm='git merge'
-alias gmom='git merge origin/master'
-alias gmt='git mergetool --no-prompt'
-alias gmtvim='git mergetool --no-prompt --tool=vimdiff'
-alias gmum='git merge upstream/master'
+alias gm='command git merge'
+alias gmom='command git merge origin/master'
+alias gmt='command git mergetool --no-prompt'
+alias gmtvim='command git mergetool --no-prompt --tool=vimdiff'
+alias gmum='command git merge upstream/master'
 
-alias gp='git push'
-alias gpd='git push --dry-run'
-alias gpoat='git push origin --all && git push origin --tags'
+alias gp='command git push'
+alias gpd='command git push --dry-run'
+alias gpoat='command git push origin --all && git push origin --tags'
 #compdef _git gpoat=git-push
-alias gpu='git push upstream'
-alias gpv='git push -v'
+alias gpu='command git push upstream'
+alias gpv='command git push -v'
 
-alias gr='git remote'
-alias gra='git remote add'
-alias grb='git rebase'
-alias grba='git rebase --abort'
-alias grbc='git rebase --continue'
-alias grbi='git rebase -i'
-alias grbm='git rebase master'
-alias grbs='git rebase --skip'
-alias grh='git reset HEAD'
-alias grhh='git reset HEAD --hard'
-alias grmv='git remote rename'
-alias grrm='git remote remove'
-alias grset='git remote set-url'
-alias grt='cd $(git rev-parse --show-toplevel || echo ".")'
-alias gru='git reset --'
-alias grup='git remote update'
-alias grv='git remote -v'
+alias gr='command git remote'
+alias gra='command git remote add'
+alias grb='command git rebase'
+alias grba='command git rebase --abort'
+alias grbc='command git rebase --continue'
+alias grbi='command git rebase -i'
+alias grbm='command git rebase master'
+alias grbs='command git rebase --skip'
+alias grh='command git reset HEAD'
+alias grhh='command git reset HEAD --hard'
+alias grmv='command git remote rename'
+alias grrm='command git remote remove'
+alias grset='command git remote set-url'
+alias grt='cd $(command git rev-parse --show-toplevel || echo ".")'
+alias gru='command git reset --'
+alias grup='command git remote update'
+alias grv='command git remote -v'
 
-alias gsb='git status -sb'
-alias gsd='git svn dcommit'
-alias gsi='git submodule init'
-alias gsps='git show --pretty=short --show-signature'
-alias gsr='git svn rebase'
-alias gss='git status -s'
-alias gst='git status'
-alias gsta='git stash save'
-alias gstaa='git stash apply'
-alias gstc='git stash clear'
-alias gstd='git stash drop'
-alias gstl='git stash list'
-alias gstp='git stash pop'
-alias gsts='git stash show --text'
-alias gsu='git submodule update'
+alias gsb='command git status -sb'
+alias gsd='command git svn dcommit'
+alias gsi='command git submodule init'
+alias gsps='command git show --pretty=short --show-signature'
+alias gsr='command git svn rebase'
+alias gss='command git status -s'
+alias gst='command git status'
+alias gsta='command git stash save'
+alias gstaa='command git stash apply'
+alias gstc='command git stash clear'
+alias gstd='command git stash drop'
+alias gstl='command git stash list'
+alias gstp='command git stash pop'
+alias gsts='command git stash show --text'
+alias gsu='command git submodule update'
 
-alias gts='git tag -s'
-alias gtv='git tag | sort -V'
+alias gts='command git tag -s'
+alias gtv='command git tag | sort -V'
 
-alias gunignore='git update-index --no-assume-unchanged'
-alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
-alias gup='git pull --rebase'
-alias gupv='git pull --rebase -v'
-alias gupa='git pull --rebase --autostash'
-alias gupav='git pull --rebase --autostash -v'
-alias glum='git pull upstream master'
+alias gunignore='command git update-index --no-assume-unchanged'
+alias gunwip='command git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
+alias gup='command git pull --rebase'
+alias gupv='command git pull --rebase -v'
+alias gupa='command git pull --rebase --autostash'
+alias gupav='command git pull --rebase --autostash -v'
+alias glum='command git pull upstream master'
 
-alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'
-alias gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify -m "--wip-- [skip ci]"'
+alias gwch='command git whatchanged -p --abbrev-commit --pretty=medium'
+alias gwip='command git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify -m "--wip-- [skip ci]"'

--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -327,25 +327,25 @@ function prompt_histdt {
 
 
 function git_status_dirty {
-  dirty=$(git status -s 2> /dev/null | tail -n 1)
+  dirty=$(command git status -s 2> /dev/null | tail -n 1)
   [[ -n $dirty ]] && echo " ●"
 }
 
 function git_stash_dirty {
-  stash=$(git stash list 2> /dev/null | tail -n 1)
+  stash=$(command git stash list 2> /dev/null | tail -n 1)
   [[ -n $stash ]] && echo " ⚑"
 }
 
 # Git: branch/detached head, dirty status
 function prompt_git {
   local ref dirty
-  if git rev-parse --is-inside-work-tree &>/dev/null; then
+  if command git rev-parse --is-inside-work-tree &>/dev/null; then
     ZSH_THEME_GIT_PROMPT_DIRTY='±'
-    dirty=$(git_status_dirty)
-    stash=$(git_stash_dirty)
-    ref=$(git symbolic-ref HEAD 2> /dev/null) ||
-      ref="➦ $(git describe --exact-match --tags HEAD 2> /dev/null)" ||
-      ref="➦ $(git show-ref --head -s --abbrev | head -n1 2> /dev/null)"
+    dirty=$(command git_status_dirty)
+    stash=$(command git_stash_dirty)
+    ref=$(command git symbolic-ref HEAD 2> /dev/null) ||
+      ref="➦ $(command git describe --exact-match --tags HEAD 2> /dev/null)" ||
+      ref="➦ $(command git show-ref --head -s --abbrev | head -n1 2> /dev/null)"
     if [[ -n $dirty ]]; then
       prompt_segment yellow black
     else

--- a/themes/cooperkid/cooperkid.theme.sh
+++ b/themes/cooperkid/cooperkid.theme.sh
@@ -14,7 +14,7 @@ GIT_SHA_PREFIX="${_omb_prompt_navy}"
 GIT_SHA_SUFFIX="${_omb_prompt_reset_color}"
 
 function git_short_sha() {
-  SHA=$(git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
+  SHA=$(command git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
 }
 
 function _omb_theme_PROMPT_COMMAND() {

--- a/themes/cupcake/cupcake.theme.sh
+++ b/themes/cupcake/cupcake.theme.sh
@@ -63,7 +63,7 @@ function winname {
 
 # Displays the current prompt
 function _omb_theme_PROMPT_COMMAND() {
-  PS1="\n${icon_start}$(_omb_prompt_print_python_venv)${icon_user}${_omb_prompt_bold_brown}\u${_omb_prompt_normal}${icon_host}${_omb_prompt_bold_teal}\h${_omb_prompt_normal}${icon_directory}${_omb_prompt_bold_purple}\W${_omb_prompt_normal}\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on ${icon_branch}  \")${_omb_prompt_white}$(scm_prompt_info)${_omb_prompt_normal}\n${icon_end}"
+  PS1="\n${icon_start}$(_omb_prompt_print_python_venv)${icon_user}${_omb_prompt_bold_brown}\u${_omb_prompt_normal}${icon_host}${_omb_prompt_bold_teal}\h${_omb_prompt_normal}${icon_directory}${_omb_prompt_bold_purple}\W${_omb_prompt_normal}\$([[ -n \$(command git branch 2> /dev/null) ]] && echo \" on ${icon_branch}  \")${_omb_prompt_white}$(scm_prompt_info)${_omb_prompt_normal}\n${icon_end}"
   PS2="${icon_end}"
 }
 

--- a/themes/doubletime/doubletime.theme.sh
+++ b/themes/doubletime/doubletime.theme.sh
@@ -33,7 +33,7 @@ function doubletime_scm_prompt {
   if [ $CHAR = $SCM_NONE_CHAR ]; then
     return
   elif [ $CHAR = $SCM_GIT_CHAR ]; then
-    echo "$(git_prompt_status)"
+    echo "$(command git_prompt_status)"
   else
     echo "[$(scm_prompt_info)]"
   fi
@@ -55,7 +55,7 @@ _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 function git_prompt_status {
   local git_status_output
-  git_status_output=$(git status 2> /dev/null )
+  git_status_output=$(command git status 2> /dev/null )
   if [ -n "$(echo $git_status_output | grep 'Changes not staged')" ]; then
     git_status="${_omb_prompt_bold_brown}$(scm_prompt_info) ✗"
   elif [ -n "$(echo $git_status_output | grep 'Changes to be committed')" ]; then

--- a/themes/hawaii50/hawaii50.theme.sh
+++ b/themes/hawaii50/hawaii50.theme.sh
@@ -118,15 +118,15 @@ function virtual_prompt_info() {
 
 # Parse git info
 function git_prompt_info() {
-    if [[ -n $(git status -s 2> /dev/null |grep -v ^# |grep -v "working directory clean") ]]; then
+    if [[ -n $(command git status -s 2> /dev/null |grep -v ^# |grep -v "working directory clean") ]]; then
         local state=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
     else
         local state=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
     fi
     local prefix=${GIT_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
     local suffix=${GIT_THEME_PROMPT_SUFFIX:-$SCM_THEME_PROMPT_SUFFIX}
-    local ref=$(git symbolic-ref HEAD 2> /dev/null) || return
-    local commit_id=$(git rev-parse HEAD 2>/dev/null) || return
+    local ref=$(command git symbolic-ref HEAD 2> /dev/null) || return
+    local commit_id=$(command git rev-parse HEAD 2>/dev/null) || return
 
     echo -e "$prefix${REF_COLOR}${ref#refs/heads/}${DEFAULT_COLOR}:${commit_id:0:$MAX_GIT_HEX_LENGTH}$state$suffix"
 }
@@ -148,17 +148,17 @@ function hg_prompt_info() {
 
 # Parse svn info
 function svn_prompt_info() {
-    if [[ -n $(svn status --ignore-externals -q 2> /dev/null) ]]; then
+    if [[ -n $(command svn status --ignore-externals -q 2> /dev/null) ]]; then
         local state=${SVN_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
     else
         local state=${SVN_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
     fi
     local prefix=${SVN_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
     local suffix=${SVN_THEME_PROMPT_SUFFIX:-$SCM_THEME_PROMPT_SUFFIX}
-    local ref=$(svn info 2> /dev/null | awk -F/ '/^URL:/ { for (i=0; i<=NF; i++) { if ($i == "branches" || $i == "tags" ) { print $(i+1); break }; if ($i == "trunk") { print $i; break } } }') || return
+    local ref=$(command svn info 2> /dev/null | awk -F/ '/^URL:/ { for (i=0; i<=NF; i++) { if ($i == "branches" || $i == "tags" ) { print $(i+1); break }; if ($i == "trunk") { print $i; break } } }') || return
     [[ -z $ref ]] && return
 
-    local revision=$(svn info 2> /dev/null | sed -ne 's#^Revision: ##p' )
+    local revision=$(command svn info 2> /dev/null | sed -ne 's#^Revision: ##p' )
 
     echo -e "$prefix${REF_COLOR}$ref${DEFAULT_COLOR}:$revision$state$suffix"
 }

--- a/themes/hawaii50/hawaii50.theme.sh
+++ b/themes/hawaii50/hawaii50.theme.sh
@@ -133,15 +133,15 @@ function git_prompt_info() {
 
 # Parse hg info
 function hg_prompt_info() {
-    if [[ -n $(hg status 2> /dev/null) ]]; then
+    if [[ -n $(command hg status 2> /dev/null) ]]; then
         local state=${HG_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
     else
         local state=${HG_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
     fi
     local prefix=${HG_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
     local suffix=${HG_THEME_PROMPT_SUFFIX:-$SCM_THEME_PROMPT_SUFFIX}
-    local branch=$(hg summary 2> /dev/null | grep branch | awk '{print $2}')
-    local changeset=$(hg summary 2> /dev/null | grep parent | awk '{print $2}')
+    local branch=$(command hg summary 2> /dev/null | grep branch | awk '{print $2}')
+    local changeset=$(command hg summary 2> /dev/null | grep parent | awk '{print $2}')
 
     echo -e "$prefix${REF_COLOR}${branch}${DEFAULT_COLOR}:${changeset#*:}$state$suffix"
 }

--- a/themes/mbriggs/mbriggs.theme.sh
+++ b/themes/mbriggs/mbriggs.theme.sh
@@ -14,7 +14,7 @@ GIT_SHA_PREFIX=" ${_omb_prompt_olive}"
 GIT_SHA_SUFFIX="${_omb_prompt_reset_color}"
 
 function git_short_sha() {
-  SHA=$(git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
+  SHA=$(command git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
 }
 
 function _omb_theme_PROMPT_COMMAND() {

--- a/themes/rana/rana.theme.sh
+++ b/themes/rana/rana.theme.sh
@@ -116,31 +116,31 @@ function prompt_git {
   local branchName=''
 
   # Check if the current directory is in a Git repository.
-  if git rev-parse --is-inside-work-tree &>/dev/null; then
+  if command git rev-parse --is-inside-work-tree &>/dev/null; then
 
     # check if the current directory is in .git before running git checks
-    if [[ $(git rev-parse --is-inside-git-dir 2> /dev/null) == false ]]; then
+    if [[ $(command git rev-parse --is-inside-git-dir 2> /dev/null) == false ]]; then
 
       # Ensure the index is up to date.
-      git update-index --really-refresh -q &>/dev/null
+      command git update-index --really-refresh -q &>/dev/null
 
       # Check for uncommitted changes in the index.
-      if ! git diff --quiet --ignore-submodules --cached; then
+      if ! command git diff --quiet --ignore-submodules --cached; then
         s+='+'
       fi
 
       # Check for unstaged changes.
-      if ! git diff-files --quiet --ignore-submodules --; then
+      if ! command git diff-files --quiet --ignore-submodules --; then
         s+='!'
       fi
 
       # Check for untracked files.
-      if [[ $(git ls-files --others --exclude-standard) ]]; then
+      if [[ $(command git ls-files --others --exclude-standard) ]]; then
         s+='?'
       fi
 
       # Check for stashed files.
-      if git rev-parse --verify refs/stash &>/dev/null; then
+      if command git rev-parse --verify refs/stash &>/dev/null; then
         s+='$'
       fi
 
@@ -150,8 +150,8 @@ function prompt_git {
     # If HEAD isn’t a symbolic ref, get the short SHA for the latest commit
     # Otherwise, just give up.
     branchName=$(
-      git symbolic-ref --quiet --short HEAD 2> /dev/null ||
-        git rev-parse --short HEAD 2> /dev/null ||
+      command git symbolic-ref --quiet --short HEAD 2> /dev/null ||
+        command git rev-parse --short HEAD 2> /dev/null ||
         echo '(unknown)')
 
     [[ $s ]] && s=" [$s]"

--- a/themes/sexy/sexy.theme.sh
+++ b/themes/sexy/sexy.theme.sh
@@ -27,16 +27,16 @@ OMB_PROMPT_CONDAENV_USE_BASENAME=true
 OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
 
 function parse_git_dirty {
-  [[ $(git status 2> /dev/null | tail -n1 | cut -c 1-17) != "nothing to commit" ]] && echo "*"
+  [[ $(command git status 2> /dev/null | tail -n1 | cut -c 1-17) != "nothing to commit" ]] && echo "*"
 }
 function parse_git_branch {
-  git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
+  command git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
 }
 
 function _omb_theme_PROMPT_COMMAND() {
   local python_venv
   _omb_prompt_get_python_venv
-  PS1="$python_venv${MAGENTA}\u ${WHITE}at ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")${PURPLE}\$(parse_git_branch)${WHITE}\n\$ ${RESET}"
+  PS1="$python_venv${MAGENTA}\u ${WHITE}at ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}\$([[ -n \$(command git branch 2> /dev/null) ]] && echo \" on \")${PURPLE}\$(parse_git_branch)${WHITE}\n\$ ${RESET}"
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND


### PR DESCRIPTION
This was largely done correctly, but several invocations of “git” were not
done with “command”. This means that they could pick up aliases for git,
such as “hub” or “lab”, which would still work, but (especially with “lab”)
make things really slow.