### PR TITLE
lib/shopt: Update CDPATH

### DIFF
--- a/lib/shopt.sh
+++ b/lib/shopt.sh
@@ -50,7 +50,7 @@ shopt -s cdspell 2> /dev/null
 # This defines where cd looks for targets
 # Add the directories you want to have fast access to, separated by colon
 # Ex: CDPATH=".:~:~/projects" will look for targets in the current working directory, in home and in the ~/projec
-CDPATH="."
+CDPATH=""
 
 # This allows you to bookmark your favorite places across the file system
 # Define a variable containing a path and you will be able to cd into it regardless of the directory you're in


### PR DESCRIPTION
Setting CDPATH to "." as a default value leads to cd showing all possible completions for the current directory twice, which leads to a non standard tab autocompletion for bash (ble.sh) showing every directory twice which is really annoying. I searched for hours to find out why my autocompletion shows me all the possible completions just for cd twice in my current directory.