### PR TITLE
base.theme.sh git branch names fix

### DIFF
--- a/themes/base.theme.sh
+++ b/themes/base.theme.sh
@@ -132,7 +132,7 @@ function scm_prompt_info_common {
 function git_clean_branch {
   local unsafe_ref=$(command git symbolic-ref -q HEAD 2> /dev/null)
   local stripped_ref=${unsafe_ref##refs/heads/}
-  local clean_ref=${stripped_ref//[^a-zA-Z0-9\/]/-}
+  local clean_ref=${stripped_ref//[^a-z_A-Z0-9\/]/-}
   echo $clean_ref
 }
 


### PR DESCRIPTION
base theme replaces underscores in a branch name.
hello_world -> hello-world

It's inconvenient when a end user copy-pastes the branch name from PS1 and 
 impossible to force everybody to use `-` in branch names.  