### PR TITLE
Added other ways to get adapter and battery status.

### DIFF
--- a/plugins/battery/battery.plugin.sh
+++ b/plugins/battery/battery.plugin.sh
@@ -4,55 +4,41 @@ function _omb_plugin_battery__upower_print_info {
   upower -i "$(upower -e | sed -n '/BAT/{p;q;}')"
 }
 
+## @fn ac_adapter_connected
+##   @exit 0 if the adapter is disconnected, or non-zero exit status
+##     otherwise.
 function ac_adapter_connected {
-  if _omb_util_command_exists upower;
-  then
+  if _omb_util_command_exists upower; then
     _omb_plugin_battery__upower_print_info | grep -qE 'state[:[:blank:]]*(charging|fully-charged)'
-    return $?
-  elif _omb_util_command_exists acpi;
-  then
+  elif _omb_util_command_exists acpi; then
     acpi -a | grep -q "on-line"
-    return $?
-  elif _omb_util_command_exists pmset;
-  then
+  elif _omb_util_command_exists pmset; then
     pmset -g batt | grep -q 'AC Power'
-    return $?
-  elif _omb_util_command_exists ioreg;
-  then
+  elif _omb_util_command_exists ioreg; then
     ioreg -n AppleSmartBattery -r | grep -q '"ExternalConnected" = Yes'
-    return $?
-  elif _omb_util_command_exists WMIC;
-  then
+  elif _omb_util_command_exists WMIC; then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=2'
-    return $?
   elif [[ -r /sys/class/power_supply/ADP0/online ]]; then
-    [[ $(cat /sys/class/power_supply/ADP0/online) == 1 ]]
+    [[ $(< /sys/class/power_supply/ADP0/online) == 1 ]]
   fi
 }
 
+## @fn ac_adapter_disconnected
+##   @exit 0 if the adapter is disconnected, or non-zero exit status
+##     otherwise.
 function ac_adapter_disconnected {
-  if _omb_util_command_exists upower;
-  then
+  if _omb_util_command_exists upower; then
     _omb_plugin_battery__upower_print_info | grep -qE 'state[:[:blank:]]*discharging'
-    return $?
-  elif _omb_util_command_exists acpi;
-  then
+  elif _omb_util_command_exists acpi; then
     acpi -a | grep -q "off-line"
-    return $?
-  elif _omb_util_command_exists pmset;
-  then
+  elif _omb_util_command_exists pmset; then
     pmset -g batt | grep -q 'Battery Power'
-    return $?
-  elif _omb_util_command_exists ioreg;
-  then
+  elif _omb_util_command_exists ioreg; then
     ioreg -n AppleSmartBattery -r | grep -q '"ExternalConnected" = No'
-    return $?
-  elif _omb_util_command_exists WMIC;
-  then
+  elif _omb_util_command_exists WMIC; then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=1'
-    return $?
   elif [[ -r /sys/class/power_supply/ADP0/online ]]; then
-    [[ $(cat /sys/class/power_supply/ADP0/online) == 0 ]]
+    [[ $(< /sys/class/power_supply/ADP0/online) == 0 ]]
   fi
 }
 
@@ -60,13 +46,11 @@ function ac_adapter_disconnected {
 ##   @about 'displays battery charge as a percentage of full (100%)'
 ##   @group 'battery'
 function battery_percentage {
-  if _omb_util_command_exists upower;
-  then
+  if _omb_util_command_exists upower; then
     local UPOWER_OUTPUT=$(_omb_plugin_battery__upower_print_info | sed -n 's/.*percentage[:[:blank:]]*\([0-9%]\{1,\}\)$/\1/p')
     [[ $UPOWER_OUTPUT ]] &&
       echo "${UPOWER_OUTPUT::-1}"
-  elif _omb_util_command_exists acpi;
-  then
+  elif _omb_util_command_exists acpi; then
     local ACPI_OUTPUT=$(acpi -b)
     case $ACPI_OUTPUT in
       *" Unknown"*)
@@ -92,8 +76,7 @@ function battery_percentage {
         echo '-1'
       ;;
     esac
-  elif _omb_util_command_exists pmset;
-  then
+  elif _omb_util_command_exists pmset; then
     local PMSET_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p')
     case $PMSET_OUTPUT in
       100*)
@@ -103,8 +86,7 @@ function battery_percentage {
         echo $PMSET_OUTPUT | head -c 2
       ;;
     esac
-  elif _omb_util_command_exists ioreg;
-  then
+  elif _omb_util_command_exists ioreg; then
     local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
     case $IOREG_OUTPUT in
       100*)
@@ -114,8 +96,7 @@ function battery_percentage {
         echo $IOREG_OUTPUT | head -c 2
       ;;
     esac
-  elif _omb_util_command_exists WMIC;
-  then
+  elif _omb_util_command_exists WMIC; then
     local WINPC=$(echo porcent=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List) | grep -o '[0-9]*')
     case $WINPC in
       100*)
@@ -126,7 +107,7 @@ function battery_percentage {
       ;;
     esac
   elif [[ -r /sys/class/power_supply/BAT0/capacity ]]; then
-    echo "$(cat /sys/class/power_supply/BAT0/capacity)"
+    echo "$(< /sys/class/power_supply/BAT0/capacity)"
   fi
 }
 

--- a/plugins/battery/battery.plugin.sh
+++ b/plugins/battery/battery.plugin.sh
@@ -25,6 +25,8 @@ function ac_adapter_connected {
   then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=2'
     return $?
+  elif [[ -r /sys/class/power_supply/ADP0/online ]]; then
+    [[ $(cat /sys/class/power_supply/ADP0/online) == 1 ]]
   fi
 }
 
@@ -49,6 +51,8 @@ function ac_adapter_disconnected {
   then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=1'
     return $?
+  elif [[ -r /sys/class/power_supply/ADP0/online ]]; then
+    [[ $(cat /sys/class/power_supply/ADP0/online) == 0 ]]
   fi
 }
 

--- a/plugins/battery/battery.plugin.sh
+++ b/plugins/battery/battery.plugin.sh
@@ -125,8 +125,8 @@ function battery_percentage {
         echo $WINPC
       ;;
     esac
-  else
-    echo "no"
+  elif [[ -r /sys/class/power_supply/BAT0/capacity ]]; then
+    echo "$(cat /sys/class/power_supply/BAT0/capacity)"
   fi
 }
 


### PR DESCRIPTION
Getting data from /sys directory will make it easier for battery plugin to work even if none of the commands tried in function [ac_adapter_connected](https://github.com/ohmybash/oh-my-bash/blob/89e505415284619377df9d8dc73f033572e24621/plugins/battery/battery.plugin.sh#L6) are available, for ex. in a docker container.