### PR TITLE
plugins/git: add git pull autostash aliases

### DIFF
--- a/plugins/git/git.plugin.sh
+++ b/plugins/git/git.plugin.sh
@@ -237,6 +237,8 @@ alias gunignore='git update-index --no-assume-unchanged'
 alias gunwip='git log -n 1 | grep -q -c "\-\-wip\-\-" && git reset HEAD~1'
 alias gup='git pull --rebase'
 alias gupv='git pull --rebase -v'
+alias gupa='git pull --rebase --autostash'
+alias gupav='git pull --rebase --autostash -v'
 alias glum='git pull upstream master'
 
 alias gwch='git whatchanged -p --abbrev-commit --pretty=medium'


### PR DESCRIPTION
Add two aliases to autostash local changes while rebasing. Those were very useful when I was using oh-my-zsh, and were missed when I migrated to oh-my-bash.