### PR TITLE
Add '_' to git branch name character whitelist

### DIFF
--- a/themes/base.theme.sh
+++ b/themes/base.theme.sh
@@ -132,7 +132,7 @@ function scm_prompt_info_common {
 function git_clean_branch {
   local unsafe_ref=$(command git symbolic-ref -q HEAD 2> /dev/null)
   local stripped_ref=${unsafe_ref##refs/heads/}
-  local clean_ref=${stripped_ref//[^a-zA-Z0-9\/]/-}
+  local clean_ref=${stripped_ref//[^a-zA-Z0-9\/_]/-}
   echo $clean_ref
 }
 


### PR DESCRIPTION
Underscore characters in git branch names are displayed in the scm prompt as hypens, so e.g. my_branch becomes my-branch.

This change adds the _ character to the branch name character whitelist