### PR TITLE
init, upgrader: minor fixes on upgrade procedure

### DIFF
--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -8,7 +8,7 @@ esac
 
 # Check for updates on initial load...
 if [ "$DISABLE_AUTO_UPDATE" != "true" ]; then
-  env OSH=$OSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT bash -f $OSH/tools/check_for_upgrade.sh
+  OSH=$OSH DISABLE_UPDATE_PROMPT=$DISABLE_UPDATE_PROMPT source $OSH/tools/check_for_upgrade.sh
 fi
 
 # Initializes Oh My Bash

--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -11,7 +11,7 @@ function _update_osh_update() {
 }
 
 function _upgrade_osh() {
-  env BASH=$OSH sh $OSH/tools/upgrade.sh
+  BASH=$OSH source $OSH/tools/upgrade.sh
   # update the osh file
   _update_osh_update
 }
@@ -42,7 +42,7 @@ if mkdir "$OSH/log/update.lock" 2>/dev/null; then
       if [ "$DISABLE_UPDATE_PROMPT" = "true" ]; then
         _upgrade_osh
       else
-        echo "[Oh My Bash] Would you like to check for updates? [Y/n]: \c"
+        echo -e "[Oh My Bash] Would you like to check for updates? [Y/n]: \c"
         read line
         if [[ "$line" == Y* ]] || [[ "$line" == y* ]] || [ -z "$line" ]; then
           _upgrade_osh

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -22,6 +22,7 @@ else
 fi
 
 printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Bash"
+OLDPWD="$PWD"
 cd "$OSH"
 if git pull --rebase --stat origin master
 then
@@ -34,7 +35,8 @@ then
   printf '%s\n' '                        /____/                            '
   printf "${BLUE}%s\n" "Hooray! Oh My Bash has been updated and/or is at the current version."
   printf "${BLUE}${BOLD}%s${NORMAL}\n" "To keep up on the latest news and updates, follow us on GitHub: https://github.com/ohmybash/oh-my-bash"
-  exec bash; source $HOME/.bashrc
+  source $HOME/.bashrc
 else
   printf "${RED}%s${NORMAL}\n" 'There was an error updating. Try again later?'
 fi
+cd "$OLDPWD"


### PR DESCRIPTION
oh-my-bash.sh, tools/check_for_upgrade.sh: use "source" instead of env+bash so no child is created
tools/check_for_upgrade.sh: "echo -e" so "\c" is effective
tools/upgrade.sh: set $OLDPWD, don't exec bash (only "source" .bashrc), cd to $OLDPWD

Fixes ohmybash/oh-my-bash#113 (update script changes PWD)