### PR TITLE
Fix install script for #213

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -38,7 +38,7 @@ main() {
   set -e
 
   if [ ! -n "$OSH" ]; then
-    OSH=$HOME/.oh-my-bash
+    OSH=~/.oh-my-bash
   fi
 
   if [ -d "$OSH" ]; then
@@ -67,23 +67,23 @@ main() {
       exit 1
     fi
   fi
-  env git clone --depth=1 https://github.com/ohmybash/oh-my-bash.git $OSH || {
+  env git clone --depth=1 https://github.com/ohmybash/oh-my-bash.git "$OSH" || {
     printf "Error: git clone of oh-my-bash repo failed\n"
     exit 1
   }
 
   printf "${BLUE}Looking for an existing bash config...${NORMAL}\n"
-  if [ -f $HOME/.bashrc ] || [ -h $HOME/.bashrc ]; then
+  if [ -f ~/.bashrc ] || [ -h ~/.bashrc ]; then
     printf "${YELLOW}Found ~/.bashrc.${NORMAL} ${GREEN}Backing up to ~/.bashrc.pre-oh-my-bash${NORMAL}\n";
-    mv $HOME/.bashrc $HOME/.bashrc.pre-oh-my-bash;
+    mv ~/.bashrc ~/.bashrc.pre-oh-my-bash;
   fi
 
   printf "${BLUE}Using the Oh My Bash template file and adding it to ~/.bashrc${NORMAL}\n"
-  cp $OSH/templates/bashrc.osh-template $HOME/.bashrc
+  cp "$OSH"/templates/bashrc.osh-template ~/.bashrc
   sed "/^export OSH=/ c\\
 export OSH=$OSH
-  " $HOME/.bashrc > $HOME/.bashrc-ombtemp
-  mv -f $HOME/.bashrc-ombtemp $HOME/.bashrc
+  " ~/.bashrc > ~/.bashrc-ombtemp
+  mv -f ~/.bashrc-ombtemp ~/.bashrc
 
   # MOTD message :)
   printf '%s' "$GREEN"
@@ -95,7 +95,7 @@ export OSH=$OSH
   printf '%s\n' '                        /____/                            .... is now installed!'
   printf "%s\n" "Please look over the ~/.bashrc file to select plugins, themes, and options"
   printf "${BLUE}${BOLD}%s${NORMAL}\n" "To keep up on the latest news and updates, follow us on GitHub: https://github.com/ohmybash/oh-my-bash"
-  exec bash; source $HOME/.bashrc
+  exec bash; source ~/.bashrc
 }
 
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -3,16 +3,16 @@
 main() {
   # Use colors, but only if connected to a terminal, and that terminal
   # supports them.
-  if which tput >/dev/null 2>&1; then
-      ncolors=$(tput colors)
+  if hash tput >/dev/null 2>&1; then
+    ncolors=$(tput colors 2>/dev/null || tput Co 2>/dev/null || echo -1)
   fi
   if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
-    RED="$(tput setaf 1)"
-    GREEN="$(tput setaf 2)"
-    YELLOW="$(tput setaf 3)"
-    BLUE="$(tput setaf 4)"
-    BOLD="$(tput bold)"
-    NORMAL="$(tput sgr0)"
+    RED=$(tput setaf 1 2>/dev/null || tput AF 1 2>/dev/null)
+    GREEN=$(tput setaf 2 2>/dev/null || tput AF 2 2>/dev/null)
+    YELLOW=$(tput setaf 3 2>/dev/null || tput AF 3 2>/dev/null)
+    BLUE=$(tput setaf 4 2>/dev/null || tput AF 4 2>/dev/null)
+    BOLD=$(tput bold 2>/dev/null || tput md 2>/dev/null)
+    NORMAL=$(tput sgr0 2>/dev/null || tput me 2>/dev/null)
   else
     RED=""
     GREEN=""

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -17,7 +17,7 @@ main() {
     ncolors=$(tput colors 2>/dev/null || tput Co 2>/dev/null || echo -1)
   fi
 
-  if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
+  if [[ -t 1 && -n $ncolors && $ncolors -ge 8 ]]; then
     RED=$(tput setaf 1 2>/dev/null || tput AF 1 2>/dev/null)
     GREEN=$(tput setaf 2 2>/dev/null || tput AF 2 2>/dev/null)
     YELLOW=$(tput setaf 3 2>/dev/null || tput AF 3 2>/dev/null)
@@ -37,11 +37,11 @@ main() {
   # which may fail on systems lacking tput or terminfo
   set -e
 
-  if [ ! -n "$OSH" ]; then
+  if [[ ! $OSH ]]; then
     OSH=~/.oh-my-bash
   fi
 
-  if [ -d "$OSH" ]; then
+  if [[ -d $OSH ]]; then
     printf "${YELLOW}You already have Oh My Bash installed.${NORMAL}\n"
     printf "You'll need to remove $OSH if you want to re-install.\n"
     exit
@@ -60,7 +60,7 @@ main() {
     exit 1
   }
   # The Windows (MSYS) Git is not compatible with normal use on cygwin
-  if [ "$OSTYPE" = cygwin ]; then
+  if [[ $OSTYPE = cygwin ]]; then
     if git --version | grep msysgit > /dev/null; then
       echo "Error: Windows/MSYS Git is not supported on Cygwin"
       echo "Error: Make sure the Cygwin git package is installed and is first on the path"
@@ -73,7 +73,7 @@ main() {
   }
 
   printf "${BLUE}Looking for an existing bash config...${NORMAL}\n"
-  if [ -f ~/.bashrc ] || [ -h ~/.bashrc ]; then
+  if [[ -f ~/.bashrc || -h ~/.bashrc ]]; then
     printf "${YELLOW}Found ~/.bashrc.${NORMAL} ${GREEN}Backing up to ~/.bashrc.pre-oh-my-bash${NORMAL}\n";
     mv ~/.bashrc ~/.bashrc.pre-oh-my-bash;
   fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
+# Checks the minium version of bash (v4) installed, 
+# stops the installation if check fails
+if [ -z "$BASH_VERSION" ] || \
+     { bash_major_version=$(echo "$BASH_VERSION" | cut -d '.' -f 1); 
+       [ "${bash_major_version}" -lt "4" ]; }; then
+  printf "Error: Bash 4 required for Oh My Bash.\n"
+  printf "Error: Upgrade Bash and try again.\n"
+  exit 1
+fi
+
 main() {
   # Use colors, but only if connected to a terminal, and that terminal
   # supports them.
   if hash tput >/dev/null 2>&1; then
     ncolors=$(tput colors 2>/dev/null || tput Co 2>/dev/null || echo -1)
   fi
+
   if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
     RED=$(tput setaf 1 2>/dev/null || tput AF 1 2>/dev/null)
     GREEN=$(tput setaf 2 2>/dev/null || tput AF 2 2>/dev/null)
@@ -25,17 +36,6 @@ main() {
   # Only enable exit-on-error after the non-critical colorization stuff,
   # which may fail on systems lacking tput or terminfo
   set -e
-
-  # Checks the minium version of bash (v4) installed, 
-  # stops the installation if check fails
-  if [ -n $BASH_VERSION ]; then
-     bash_major_version=$(echo $BASH_VERSION | cut -d '.' -f 1)
-     if [ "${bash_major_version}" -lt "4" ]; then
-        printf "Error: Bash 4 required for Oh My Bash.\n"
-        printf "Error: Upgrade Bash and try again.\n"
-        exit 1
-     fi
-  fi
 
   if [ ! -n "$OSH" ]; then
     OSH=$HOME/.oh-my-bash

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
-# Checks the minium version of bash (v4) installed, 
+# Checks the minium version of bash (v3.2) installed, 
 # stops the installation if check fails
-if [ -z "$BASH_VERSION" ] || \
-     { bash_major_version=$(echo "$BASH_VERSION" | cut -d '.' -f 1); 
-       [ "${bash_major_version}" -lt "4" ]; }; then
-  printf "Error: Bash 4 required for Oh My Bash.\n"
+if [ -z "${BASH_VERSION-}" ]; then
+  printf "Error: Bash 3.2 required for Oh My Bash.\n"
+  printf "Error: Install Bash and try running this script with Bash.\n"
+  exit 1
+fi
+
+if [[ ! ${BASH_VERSINFO[0]-} ]] || ((BASH_VERSINFO[0] < 3 || BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2)); then
+  printf "Error: Bash 3.2 required for Oh My Bash.\n"
   printf "Error: Upgrade Bash and try again.\n"
   exit 1
 fi

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -7,22 +7,22 @@ if [ "$confirmation" != y ] && [ "$confirmation" != Y ]; then
 fi
 
 echo "Removing ~/.oh-my-bash"
-if [ -d $HOME/.oh-my-bash ]; then
-  rm -rf $HOME/.oh-my-bash
+if [ -d ~/.oh-my-bash ]; then
+  rm -rf ~/.oh-my-bash
 fi
 
 echo "Looking for original bash config..."
-if [ -f $HOME/.bashrc.pre-oh-my-bash ] || [ -h $HOME/.bashrc.pre-oh-my-bash ]; then
+if [ -f ~/.bashrc.pre-oh-my-bash ] || [ -h ~/.bashrc.pre-oh-my-bash ]; then
   echo "Found ~/.bashrc.pre-oh-my-bash -- Restoring to ~/.bashrc";
 
-  if [ -f $HOME/.bashrc ] || [ -h $HOME/.bashrc ]; then
+  if [ -f ~/.bashrc ] || [ -h ~/.bashrc ]; then
     bashrc_SAVE=".bashrc.omb-uninstalled-$(date +%Y%m%d%H%M%S)";
     echo "Found ~/.bashrc -- Renaming to ~/${bashrc_SAVE}";
-    mv $HOME/.bashrc $HOME/"${bashrc_SAVE}";
+    mv ~/.bashrc ~/"${bashrc_SAVE}";
   fi
 
-  mv $HOME/.bashrc.pre-oh-my-bash $HOME/.bashrc;
-  exec bash; source $HOME/.bashrc
+  mv ~/.bashrc.pre-oh-my-bash ~/.bashrc;
+  exec bash; source ~/.bashrc
 
   echo "Your original bash config was restored. Please restart your session."
 else


### PR DESCRIPTION
Fix #213. There are several issues in the current install script. This PR tries to fix them. I separated commits for each fixes as follows. Thank you.

### Add support for termcap-based tput 02620c8

As I have already commented in ***, `tput` may support `termcap` names instead of `terminfo` names depending on the system.

Also, I have changed `which` to `hash` as is later used to test `git`. `which` is not a POSIX utility, so it may be missing.  `hash` is a builtin command of Bash so always available while running in Bash.

The right-hand sides of assignments is not subject to word splitting or pathname expansions, so quotation is unneeded for the command substitutions.

### Fix the version check 03ee310

```
[ -n $BASH_VERSION ]
```

In Bash and POSIX shells (unlike the default of Zsh), the unquoted parameter expansion `$BASH_VERSION` is subject to word splitting and pathname expansions.  When `BASH_VERSION` is an empty string, it will be `[ -n ]`.  When `[ ... ]` receives only a single argument, it just tests whether the argument is non-empty.  It just tests if the string `-n` is non-empty, which is always true.  One needs to quote `$BASH_VERSION`.

Also, we should first test the shell version outside the function because less-functional shells may fail to parse the function itself before it checks the shell version in the function.  For example, the original Bourne shell doesn't understand the command substitution of the form `$(...)`.

In case it matters, the version check code was introduced by e66772b.

### Quote arguments properly 599e277

In Bash and POSIX shells (unlike the default of Zsh), the unquoted arguments undergo word splitting and pathname expansions.  For example, the unquoted `$HOME` will be split to multiple words when `HOME` contains spaces or when `IFS` contains characters in `HOME`.

Also, instead of quoting `$HOME`, one may use `~` in the beginning of words and right-hand sides of assignments.

### Use conditional command 2f2a12d

In Bash, instead of `[`, it is recommended to use the special compound command `[[ ... ]]`, for which the syntactic treatment of the arguments are different from the one in the normal context.
