### PR TITLE
Fix the violation of the MIT license of Oh My Zsh

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,4 @@
+Copyright (c) 2009-2017 Robby Russell and contributors (https://github.com/ohmyzsh/ohmyzsh/contributors)
 Copyright 2017-2020 Toan Nguyen and contributors (https://github.com/ohmybash/oh-my-bash/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.md
+++ b/README.md
@@ -198,4 +198,5 @@ Thank you so much!
 
 ## License
 
+Oh My Bash is derived from [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh).
 Oh My Bash is released under the [MIT license](LICENSE.md).


### PR DESCRIPTION
The MIT license does not allow to remove the original copyright notice. See #151.