### PR TITLE
Replace `which` with `command -v`

### DIFF
--- a/completions/awscli.completion.sh
+++ b/completions/awscli.completion.sh
@@ -1,2 +1,2 @@
 #! bash oh-my-bash.module
-[[ -x "$(which aws_completer)" ]] &>/dev/null && complete -C "$(which aws_completer)" aws
+_omb_util_binary_exists aws_completer && complete -C "$(type -P aws_completer)" aws

--- a/completions/conda.completion.sh
+++ b/completions/conda.completion.sh
@@ -1,4 +1,4 @@
 #! bash oh-my-bash.module
-which register-python-argcomplete &> /dev/null \
+_omb_util_binary_exists register-python-argcomplete \
   && eval "$(register-python-argcomplete conda)" \
   || echo "Please install argcomplete to use conda completion" > /dev/null

--- a/completions/conda.completion.sh
+++ b/completions/conda.completion.sh
@@ -1,4 +1,4 @@
 #! bash oh-my-bash.module
 _omb_util_binary_exists register-python-argcomplete \
   && eval "$(register-python-argcomplete conda)" \
-  || echo "Please install argcomplete to use conda completion" > /dev/null
+  || echo "Please install argcomplete to use conda completion"

--- a/completions/django.completion.sh
+++ b/completions/django.completion.sh
@@ -59,7 +59,7 @@ _python_django_completion()
 
 # Support for multiple interpreters.
 unset pythons
-if command -v whereis &>/dev/null; then
+if _omb_util_command_exists whereis; then
     python_interpreters=$(whereis python | cut -d " " -f 2-)
     for python in $python_interpreters; do
         pythons="${pythons} $(basename -- $python)"

--- a/completions/docker-compose.completion.sh
+++ b/completions/docker-compose.completion.sh
@@ -552,7 +552,7 @@ _docker_compose() {
 	done
 
 	local completions_func=_docker_compose_${command//-/_}
-	_omb_util_function_exists $completions_func && $completions_func
+	_omb_util_function_exists "$completions_func" && "$completions_func"
 
 	eval "$previous_extglob_setting"
 	return 0

--- a/completions/docker-compose.completion.sh
+++ b/completions/docker-compose.completion.sh
@@ -39,7 +39,7 @@ __docker_compose_to_extglob() {
 # suppress trailing whitespace
 __docker_compose_nospace() {
 	# compopt is not available in ancient bash versions
-	type compopt &>/dev/null && compopt -o nospace
+	_omb_util_command_exists compopt && compopt -o nospace
 }
 
 # Extracts all service names from the compose file.

--- a/completions/docker-compose.completion.sh
+++ b/completions/docker-compose.completion.sh
@@ -552,7 +552,7 @@ _docker_compose() {
 	done
 
 	local completions_func=_docker_compose_${command//-/_}
-	declare -F $completions_func >/dev/null && $completions_func
+	_omb_util_function_exists $completions_func && $completions_func
 
 	eval "$previous_extglob_setting"
 	return 0

--- a/completions/docker-machine.completion.sh
+++ b/completions/docker-machine.completion.sh
@@ -243,7 +243,7 @@ _docker_machine() {
     done
 
     local completion_func=_docker_machine_"${command//-/_}"
-    if declare -F "${completion_func}" > /dev/null; then
+    if _omb_util_function_exists "${completion_func}"; then
         ${completion_func}
     fi
 

--- a/completions/docker-machine.completion.sh
+++ b/completions/docker-machine.completion.sh
@@ -244,7 +244,7 @@ _docker_machine() {
 
     local completion_func=_docker_machine_"${command//-/_}"
     if _omb_util_function_exists "${completion_func}"; then
-        ${completion_func}
+        "${completion_func}"
     fi
 
     return 0

--- a/completions/docker.completion.sh
+++ b/completions/docker.completion.sh
@@ -394,7 +394,7 @@ __docker_subcommands() {
 				subcommand_pos=$counter
 				local subcommand=${words[$counter]}
 				local completions_func=_docker_${command}_${subcommand}
-				declare -F $completions_func >/dev/null && $completions_func
+				_omb_util_function_exists $completions_func && $completions_func
 				return 0
 				;;
 		esac
@@ -2953,7 +2953,7 @@ _docker() {
 	fi
 
 	local completions_func=_docker_${command}
-	declare -F $completions_func >/dev/null && $completions_func
+	_omb_util_function_exists $completions_func && $completions_func
 
 	eval "$previous_extglob_setting"
 	return 0

--- a/completions/docker.completion.sh
+++ b/completions/docker.completion.sh
@@ -410,7 +410,7 @@ __docker_nospace() {
 }
 
 __docker_complete_resolved_hostname() {
-	command -v host >/dev/null 2>&1 || return
+	_omb_util_command_exists host || return
 	COMPREPLY=( $(host 2>/dev/null "${cur%:}" | awk '/has address/ {print $4}') )
 }
 

--- a/completions/docker.completion.sh
+++ b/completions/docker.completion.sh
@@ -406,7 +406,7 @@ __docker_subcommands() {
 # suppress trailing whitespace
 __docker_nospace() {
 	# compopt is not available in ancient bash versions
-	type compopt &>/dev/null && compopt -o nospace
+	_omb_util_command_exists compopt && compopt -o nospace
 }
 
 __docker_complete_resolved_hostname() {

--- a/completions/docker.completion.sh
+++ b/completions/docker.completion.sh
@@ -394,7 +394,7 @@ __docker_subcommands() {
 				subcommand_pos=$counter
 				local subcommand=${words[$counter]}
 				local completions_func=_docker_${command}_${subcommand}
-				_omb_util_function_exists $completions_func && $completions_func
+				_omb_util_function_exists "$completions_func" && "$completions_func"
 				return 0
 				;;
 		esac
@@ -2953,7 +2953,7 @@ _docker() {
 	fi
 
 	local completions_func=_docker_${command}
-	_omb_util_function_exists $completions_func && $completions_func
+	_omb_util_function_exists "$completions_func" && "$completions_func"
 
 	eval "$previous_extglob_setting"
 	return 0

--- a/completions/drush.completion.sh
+++ b/completions/drush.completion.sh
@@ -7,7 +7,7 @@
 #   http://github.com/drush-ops/drush/blob/master/drush.complete.sh
 
 # Ensure drush is available.
-which drush &> /dev/null || alias drush &> /dev/null || return
+_omb_util_command_exists drush || return
 
 __drush_ps1() {
   f="${TMPDIR:-/tmp/}/drush-env/drush-drupal-site-$$"

--- a/completions/fabric-completion.sh
+++ b/completions/fabric-completion.sh
@@ -80,7 +80,7 @@ function __fab_fabfile_mtime() {
 #
 function __fab_completion() {
     # Return if "fab" command doesn't exists
-    [[ -e `which fab 2> /dev/null` ]] || return 0
+    _omb_util_binary_exists fab || return 0
 
     # Variables to hold the current word and possible matches
     local cur="${COMP_WORDS[COMP_CWORD]}"

--- a/completions/gh.completion.sh
+++ b/completions/gh.completion.sh
@@ -3,7 +3,7 @@
 # This script complements the completion script that ships with git.
 
 # Check that git tab completion is available
-if declare -F _git > /dev/null; then
+if _omb_util_function_exists _git; then
   # Duplicate and rename the 'list_all_commands' function
   eval "$(declare -f __git_list_all_commands | \
         sed 's/__git_list_all_commands/__git_list_all_commands_without_hub/')"

--- a/completions/hub.completion.sh
+++ b/completions/hub.completion.sh
@@ -3,12 +3,12 @@
 # This script complements the completion script that ships with git.
 
 # If there is no git tab completion, but we have the _completion loader try to load it
-if ! declare -F _git > /dev/null && declare -F _completion_loader > /dev/null; then
+if ! _omb_util_function_exists _git && _omb_util_function_exists _completion_loader; then
   _completion_loader git
 fi
 
 # Check that git tab completion is available
-if declare -F _git > /dev/null; then
+if _omb_util_function_exists _git; then
   # Duplicate and rename the 'list_all_commands' function
   eval "$(declare -f __git_list_all_commands | \
         sed 's/__git_list_all_commands/__git_list_all_commands_without_hub/')"

--- a/completions/jungle.completion.sh
+++ b/completions/jungle.completion.sh
@@ -1,2 +1,2 @@
 #! bash oh-my-bash.module
-[[ -x "$(which jungle)" ]] &>/dev/null  && eval "$(_JUNGLE_COMPLETE=source jungle)"
+_omb_util_binary_exists jungle && eval "$(_JUNGLE_COMPLETE=source jungle)"

--- a/completions/kontena.completion.sh
+++ b/completions/kontena.completion.sh
@@ -1,2 +1,2 @@
 #! bash oh-my-bash.module
-which kontena &> /dev/null && . "$( kontena whoami --bash-completion-path )"
+_omb_util_binary_exists kontena && . "$( kontena whoami --bash-completion-path )"

--- a/completions/kubectl.completion.sh
+++ b/completions/kubectl.completion.sh
@@ -2,7 +2,7 @@
 
 # kubectl (Kubernetes CLI) completion
 
-if command -v kubectl &>/dev/null
+if _omb_util_command_exists kubectl
 then
   eval "$(kubectl completion bash)"
 fi

--- a/completions/maven.completion.sh
+++ b/completions/maven.completion.sh
@@ -6,8 +6,8 @@
 
 function_exists()
 {
-	_omb_util_function_exists $1
-	return $?
+	_omb_util_function_exists "$1"
+	return "$?"
 }
 
 function_exists _get_comp_words_by_ref ||

--- a/completions/maven.completion.sh
+++ b/completions/maven.completion.sh
@@ -6,7 +6,7 @@
 
 function_exists()
 {
-	declare -F $1 > /dev/null
+	_omb_util_function_exists $1
 	return $?
 }
 

--- a/completions/minikube.completion.sh
+++ b/completions/minikube.completion.sh
@@ -2,7 +2,7 @@
 
 # minikube (Kubernetes CLI) completion
 
-if command -v minikube &>/dev/null
+if _omb_util_command_exists minikube
 then
   eval "$(minikube completion bash)"
 fi

--- a/completions/npm.completion.sh
+++ b/completions/npm.completion.sh
@@ -3,7 +3,7 @@
 # npm (Node Package Manager) completion
 # https://docs.npmjs.com/cli/completion
 
-if command -v npm &>/dev/null
+if _omb_util_command_exists npm
 then
   eval "$(npm completion)"
 fi

--- a/completions/packer.completion.sh
+++ b/completions/packer.completion.sh
@@ -130,7 +130,7 @@ _packer_completion ()
     # Words containing an equal sign get split into tokens in bash > 4, which
     # doesn't come in handy here.
     # This is handled here. bash < 4 does not split.
-    declare -f _get_comp_words_by_ref >/dev/null && _get_comp_words_by_ref -n = cur
+    _omb_util_function_exists _get_comp_words_by_ref && _get_comp_words_by_ref -n = cur
 
     COMPREPLY=()
     local i c=1 command
@@ -157,7 +157,7 @@ _packer_completion ()
     fi
 
     local completion_func="__packer_${command}"
-    declare -f $completion_func >/dev/null && $completion_func
+    _omb_util_function_exists $completion_func && $completion_func
 }
 
 complete -o nospace -F _packer_completion packer

--- a/completions/packer.completion.sh
+++ b/completions/packer.completion.sh
@@ -133,7 +133,7 @@ _packer_completion ()
     _omb_util_function_exists _get_comp_words_by_ref && _get_comp_words_by_ref -n = cur
 
     COMPREPLY=()
-    local i c=1 command
+    local i c=1 command=
 
     while [ $c -lt $COMP_CWORD ]; do
         i="${COMP_WORDS[c]}"
@@ -144,7 +144,7 @@ _packer_completion ()
         ((c++))
     done
 
-    if [ -z $command ]; then
+    if [ -z "$command" ]; then
         case "$cur" in
             '-'*)
                 __packercomp "-machine-readable --help --version"
@@ -157,7 +157,7 @@ _packer_completion ()
     fi
 
     local completion_func="__packer_${command}"
-    _omb_util_function_exists $completion_func && $completion_func
+    _omb_util_function_exists "$completion_func" && "$completion_func"
 }
 
 complete -o nospace -F _packer_completion packer

--- a/completions/system.completion.sh
+++ b/completions/system.completion.sh
@@ -13,7 +13,7 @@ if [ -f /etc/profile.d/bash_completion.sh ]; then
 fi
 
 
-if [ $(uname) = "Darwin" ] && command -v brew &>/dev/null ; then
+if [ $(uname) = "Darwin" ] && _omb_util_command_exists brew; then
   BREW_PREFIX=$(brew --prefix)
 
   if [ -f "$BREW_PREFIX"/etc/bash_completion ]; then

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -197,10 +197,10 @@ bigfind() {
 #   ips:  display all ip addresses for this host
 #   -------------------------------------------------------------------
     ips () {
-      if command -v ifconfig &>/dev/null
+      if _omb_util_command_exists ifconfig
       then
         ifconfig | awk '/inet /{ print $2 }'
-      elif command -v ip &>/dev/null
+      elif _omb_util_command_exists ip
       then
         ip addr | grep -oP 'inet \K[\d.]+'
       else

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -272,12 +272,6 @@ bigfind() {
       fi
     }
 
-#   command_exists: checks for existence of a command (0 = true, 1 = false)
-#   -------------------------------------------------------------------
-    command_exists () {
-      type "$1" &> /dev/null ;
-    }
-
 #   pickfrom: picks random line from file
 #   -------------------------------------------------------------------
     pickfrom () {

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -124,7 +124,7 @@ zipf () { zip -r "$1".zip "$1" ; }           # zipf:         To create a ZIP arc
 #   mkiso:  creates iso from current dir in the parent dir (unless defined)
 #   ---------------------------------------------------------
     mkiso () {
-      if type "mkisofs" > /dev/null; then
+      if _omb_util_command_exists mkisofs; then
         if [ -z ${1+x} ]; then
           local isoname=${PWD##*/}
         else

--- a/lib/misc.sh
+++ b/lib/misc.sh
@@ -11,7 +11,7 @@ _omb_util_alias _='sudo'
 _omb_util_alias please='sudo'
 
 ## more intelligent acking for ubuntu users
-if which ack-grep &> /dev/null; then
+if _omb_util_binary_exists ack-grep; then
   _omb_util_alias afind='ack-grep -il'
 else
   _omb_util_alias afind='ack -il'

--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -104,9 +104,9 @@ function _omb_prompt_format {
 function scm {
   if [[ "$SCM_CHECK" = false ]]; then SCM=$SCM_NONE
   elif [[ -f .git/HEAD ]]; then SCM=$SCM_GIT
-  elif which git &> /dev/null && [[ -n "$(git rev-parse --is-inside-work-tree 2> /dev/null)" ]]; then SCM=$SCM_GIT
+  elif _omb_util_binary_exists git && [[ -n "$(git rev-parse --is-inside-work-tree 2> /dev/null)" ]]; then SCM=$SCM_GIT
   elif [[ -d .hg ]]; then SCM=$SCM_HG
-  elif which hg &> /dev/null && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
+  elif _omb_util_binary_exists hg && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
   elif [[ -d .svn ]]; then SCM=$SCM_SVN
   else SCM=$SCM_NONE
   fi

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -403,7 +403,7 @@ _omb_util_alias() {
 
 function _omb_util_mktemp {
   local template=tmp.oh-my-bash.XXXXXXXXXX
-  if type -t mktemp &>/dev/null; then
+  if _omb_util_command_exists mktemp; then
     mktemp -t "$template"
   else
     m4 -D template="${TMPDIR:-/tmp}/$template" <<< 'mkstemp(template)'

--- a/plugins/battery/battery.plugin.sh
+++ b/plugins/battery/battery.plugin.sh
@@ -1,30 +1,27 @@
 #! bash oh-my-bash.module
 
-# Bug: https://github.com/ohmybash/oh-my-bash/issues/68
-if ! command -v "command_exists" >/dev/null; then	command_exists() { command -v "$1" >/dev/null ;	} fi
-
 _omb_plugin_battery__upower_print_info() {
   upower -i "$(upower -e | sed -n '/BAT/{p;q;}')"
 }
 
 ac_adapter_connected(){
-  if command_exists upower;
+  if _omb_util_command_exists upower;
   then
     _omb_plugin_battery__upower_print_info | grep -qE 'state[:[:blank:]]*(charging|fully-charged)'
     return $?
-  elif command_exists acpi;
+  elif _omb_util_command_exists acpi;
   then
     acpi -a | grep -q "on-line"
     return $?
-  elif command_exists pmset;
+  elif _omb_util_command_exists pmset;
   then
     pmset -g batt | grep -q 'AC Power'
     return $?
-  elif command_exists ioreg;
+  elif _omb_util_command_exists ioreg;
   then
     ioreg -n AppleSmartBattery -r | grep -q '"ExternalConnected" = Yes'
     return $?
-  elif command_exists WMIC;
+  elif _omb_util_command_exists WMIC;
   then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=2'
     return $?
@@ -32,23 +29,23 @@ ac_adapter_connected(){
 }
 
 ac_adapter_disconnected(){
-  if command_exists upower;
+  if _omb_util_command_exists upower;
   then
     _omb_plugin_battery__upower_print_info | grep -qE 'state[:[:blank:]]*discharging'
     return $?
-  elif command_exists acpi;
+  elif _omb_util_command_exists acpi;
   then
     acpi -a | grep -q "off-line"
     return $?
-  elif command_exists pmset;
+  elif _omb_util_command_exists pmset;
   then
     pmset -g batt | grep -q 'Battery Power'
     return $?
-  elif command_exists ioreg;
+  elif _omb_util_command_exists ioreg;
   then
     ioreg -n AppleSmartBattery -r | grep -q '"ExternalConnected" = No'
     return $?
-  elif command_exists WMIC;
+  elif _omb_util_command_exists WMIC;
   then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=1'
     return $?
@@ -59,12 +56,12 @@ ac_adapter_disconnected(){
 ##   @about 'displays battery charge as a percentage of full (100%)'
 ##   @group 'battery'
 battery_percentage(){
-  if command_exists upower;
+  if _omb_util_command_exists upower;
   then
     local UPOWER_OUTPUT=$(_omb_plugin_battery__upower_print_info | sed -n 's/.*percentage[:[:blank:]]*\([0-9%]\{1,\}\)$/\1/p')
     [[ $UPOWER_OUTPUT ]] &&
       echo "${UPOWER_OUTPUT::-1}"
-  elif command_exists acpi;
+  elif _omb_util_command_exists acpi;
   then
     local ACPI_OUTPUT=$(acpi -b)
     case $ACPI_OUTPUT in
@@ -91,7 +88,7 @@ battery_percentage(){
         echo '-1'
       ;;
     esac
-  elif command_exists pmset;
+  elif _omb_util_command_exists pmset;
   then
     local PMSET_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p')
     case $PMSET_OUTPUT in
@@ -102,7 +99,7 @@ battery_percentage(){
         echo $PMSET_OUTPUT | head -c 2
       ;;
     esac
-  elif command_exists ioreg;
+  elif _omb_util_command_exists ioreg;
   then
     local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
     case $IOREG_OUTPUT in
@@ -113,7 +110,7 @@ battery_percentage(){
         echo $IOREG_OUTPUT | head -c 2
       ;;
     esac
-  elif command_exists WMIC;
+  elif _omb_util_command_exists WMIC;
   then
     local WINPC=$(echo porcent=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List) | grep -o '[0-9]*')
     case $WINPC in

--- a/plugins/nvm/nvm.plugin.sh
+++ b/plugins/nvm/nvm.plugin.sh
@@ -5,7 +5,7 @@
 
 
 # Try to load nvm only if command not already available
-if ! type "nvm" &> /dev/null; then
+if ! _omb_util_command_exists nvm; then
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
   # This is done as part of completions!!!
   # [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/themes/brainy/brainy.theme.sh
+++ b/themes/brainy/brainy.theme.sh
@@ -135,8 +135,8 @@ ___brainy_prompt_ruby() {
 }
 
 ___brainy_prompt_todo() {
-	[ "${THEME_SHOW_TODO}" != "true" ] ||
-	[ -z "$(which todo.sh)" ] && return
+	[ "${THEME_SHOW_TODO}" != "true" ] && return
+	_omb_util_binary_exists todo.sh || return
 	color=$_omb_prompt_bold_white
 	box="[|]"
 	info="t:$(todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+)" | awk '{ print $4 }' )"

--- a/themes/dulcie/dulcie.theme.sh
+++ b/themes/dulcie/dulcie.theme.sh
@@ -77,7 +77,7 @@ _omb_theme_PROMPT_COMMAND() {
   printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
 
   # Open the new terminal in the same directory
-  declare -f __vte_osc7 > /dev/null && __vte_osc7
+  _omb_util_function_exists __vte_osc7 && __vte_osc7
 
   PS1="${_omb_prompt_reset_color}[${DULCIE_USER}@${DULCIE_HOST}$(scm_prompt_info)${_omb_prompt_reset_color} ${DULCIE_WORKINGDIR}]"
   if [[ "${DULCIE_MULTILINE}" -eq "1" ]]; then

--- a/tools/autossh.sh
+++ b/tools/autossh.sh
@@ -16,7 +16,7 @@ ALIVE=0
 HISTFILE="$HOME/.autossh.history"
 
 # Use colors, but only if connected to a terminal, and that terminal supports them.
-if which tput >/dev/null 2>&1; then
+if type -P tput >/dev/null 2>&1; then
   ncolors=$(tput colors)
 fi
 if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -176,7 +176,7 @@ _omb_install_system_bashrc() {
 _omb_install_main() {
   # Use colors, but only if connected to a terminal, and that terminal
   # supports them.
-  if hash tput >/dev/null 2>&1; then
+  if type -P tput &>/dev/null; then
     local ncolors=$(tput colors 2>/dev/null || tput Co 2>/dev/null || echo -1)
   fi
 


### PR DESCRIPTION
Debian has deprecated usage of `which`, as per:
https://salsa.debian.org/debian/debianutils/-/commit/3a8dd10b4502f7bae8fc6973c13ce23fc9da7efb

The recommendation is now to use `command -v`.