### PR TITLE
themes/powerline: Add kubernetes cluster context info

### DIFF
--- a/themes/powerline/README.md
+++ b/themes/powerline/README.md
@@ -18,6 +18,7 @@ A colorful theme, where shows a lot information about your shell session.
 * SCM Repository status (e.g. Git, SVN)
 * The current Python environment (Virtualenv, venv, and Conda are supported) in use
 * The current Ruby environment (rvm and rbenv are supported) in use
+* The current Kubernetes context in use (need kubectl)
 * Last command exit code (only shown when the exit code is greater than 0)
 
 ## Configuration
@@ -52,6 +53,7 @@ The contents of the prompt can be "reordered", all the "segments" (every piece o
 * ruby
 * scm
 * user_info
+* k8s_info
 
 A variables can be defined to set the order of the prompt segments:
 

--- a/themes/powerline/powerline.base.sh
+++ b/themes/powerline/powerline.base.sh
@@ -121,6 +121,19 @@ function __powerline_in_vim_prompt {
   fi
 }
 
+function __powerline_k8s_info_prompt {
+  if type_exists 'kubectl'; then
+    local k8s_cluster="$(kubectl config current-context 2>/dev/null)"
+    if [[ -z "$k8s_cluster" ]]; then
+      echo ""
+    else
+      local k8s_namespace="$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
+      k8s_namespace="${k8s_namespace:-default}"
+      echo "${k8s_cluster}:${k8s_namespace}|${K8S_INFO_THEME_PROMPT_COLOR}"
+    fi
+  fi
+}
+
 function __powerline_left_segment {
   local OLD_IFS="${IFS}"; IFS="|"
   local params=( $1 )

--- a/themes/powerline/powerline.theme.sh
+++ b/themes/powerline/powerline.theme.sh
@@ -46,6 +46,8 @@ THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:="%H:%M:%S"}
 IN_VIM_THEME_PROMPT_COLOR=245
 IN_VIM_THEME_PROMPT_TEXT="vim"
 
+K8S_INFO_THEME_PROMPT_COLOR=57
+
 POWERLINE_PROMPT=${POWERLINE_PROMPT:="user_info scm python_venv ruby cwd"}
 
 safe_append_prompt_command __powerline_prompt_command


### PR DESCRIPTION
Hi, 

I just found out about your project and I really like it, especially with the **powerline-multiline theme.**
I often manage several kubernetes clusters and it is very useful for me to know directly what my current context is.
I started to develop the function which allows to retrieve information on the current cluster and the selected namespace.

It works on my side but being far from good at bash if someone can suggest modifications or optimization that will be nice.

Last thing, I'm not sure I understood how the export of the `powerline.theme.sh` file vars works because my variable added here to configure the color is not exported.

Thanks,

![Screenshot from 2021-12-11 16-51-47](https://user-images.githubusercontent.com/29121316/145682865-79f77998-0e39-4913-a0df-e6a1eb8cd086.png)

