### PR TITLE
oh-my-bash: Add a function for dependency resolution and refactor

### DIFF
--- a/lib/omb-deprecate.sh
+++ b/lib/omb-deprecate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# deprecate functions
+
+# oh-my-bash.sh -- These functions were originally used to find
+# "fpath" directories, which are not supported by Bash.
+
+is_plugin() {
+  local base_dir=$1 name=$2
+  [[ -f $base_dir/plugins/$name/$name.plugin.sh || -f $base_dir/plugins/$name/_$name ]]
+}
+
+is_completion() {
+  local base_dir=$1 name=$2
+  [[ -f $base_dir/completions/$name/$name.completion.sh ]]
+}
+
+is_alias() {
+  local base_dir=$1 name=$2
+  [[ -f $base_dir/aliases/$name/$name.aliases.sh ]]
+}

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -263,3 +263,28 @@ _omb_util_add_prompt_command() {
     PROMPT_COMMAND="$1${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
   fi
 }
+
+_omb_util_glob_expand() {
+  local set=$- shopt=$BASHOPTS gignore=$GLOBIGNORE
+
+  shopt -u failglob
+  shopt -s nullglob
+  shopt -s extglob
+  set +f
+  GLOBIGNORE=
+
+  eval -- "$1=($2)"
+
+  GLOBIGNORE=$gignore
+  # Note: dotglob is changed by GLOBIGNORE
+  if [[ :$shopt: == *:dotglob:* ]]; then
+    shopt -s dotglob
+  else
+    shopt -u dotglob
+  fi
+  [[ $set == *f* ]] && set -f
+  [[ :$shopt: != *:extglob:* ]] && shopt -u extglob
+  [[ :$shopt: != *:nullglob:* ]] && shopt -u nullglob
+  [[ :$shopt: == *:failglob:* ]] && shopt -s failglob
+  return 0
+}

--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -13,9 +13,6 @@ fi
 
 # Initializes Oh My Bash
 
-# add a function path
-fpath=($OSH/functions $fpath)
-
 # Set OSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
 if [[ -z "$OSH_CUSTOM" ]]; then
@@ -34,53 +31,6 @@ for config_file in $OSH/lib/*.sh; do
   custom_config_file="${OSH_CUSTOM}/lib/$(basename "${config_file}")"
   [ -f "${custom_config_file}" ] && config_file=${custom_config_file}
   source $config_file
-done
-
-
-is_plugin() {
-  local base_dir=$1
-  local name=$2
-  test -f $base_dir/plugins/$name/$name.plugin.sh \
-    || test -f $base_dir/plugins/$name/_$name
-}
-# Add all defined plugins to fpath. This must be done
-# before running compinit.
-for plugin in ${plugins[@]}; do
-  if is_plugin $OSH_CUSTOM $plugin; then
-    fpath=($OSH_CUSTOM/plugins/$plugin $fpath)
-  elif is_plugin $OSH $plugin; then
-    fpath=($OSH/plugins/$plugin $fpath)
-  fi
-done
-
-is_completion() {
-  local base_dir=$1
-  local name=$2
-  test -f $base_dir/completions/$name/$name.completion.sh
-}
-# Add all defined completions to fpath. This must be done
-# before running compinit.
-for completion in ${completions[@]}; do
-  if is_completion $OSH_CUSTOM $completion; then
-    fpath=($OSH_CUSTOM/completions/$completion $fpath)
-  elif is_completion $OSH $completion; then
-    fpath=($OSH/completions/$completion $fpath)
-  fi
-done
-
-is_alias() {
-  local base_dir=$1
-  local name=$2
-  test -f $base_dir/aliases/$name/$name.aliases.sh
-}
-# Add all defined completions to fpath. This must be done
-# before running compinit.
-for alias in ${aliases[@]}; do
-  if is_alias $OSH_CUSTOM $alias; then
-    fpath=($OSH_CUSTOM/aliases/$alias $fpath)
-  elif is_alias $OSH $alias; then
-    fpath=($OSH/aliases/$alias $fpath)
-  fi
 done
 
 # Figure out the SHORT hostname

--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -15,23 +15,74 @@ fi
 
 # Set OSH_CUSTOM to the path where your custom config files
 # and plugins exists, or else we will use the default custom/
-if [[ -z "$OSH_CUSTOM" ]]; then
-    OSH_CUSTOM="$OSH/custom"
-fi
+: "${OSH_CUSTOM:=$OSH/custom}"
 
 # Set OSH_CACHE_DIR to the path where cache files should be created
 # or else we will use the default cache/
-if [[ -z "$OSH_CACHE_DIR" ]]; then
-  OSH_CACHE_DIR="$OSH/cache"
-fi
+: "${OSH_CACHE_DIR:=$OSH/cache}"
+
+_omb_module_loaded=
+_omb_module_require() {
+  local status=0
+  local -a files=()
+  while (($#)); do
+    local type=lib name=$1; shift
+    [[ $name == *:* ]] && type=${name%%:*} name=${name#*:}
+    name=${name%.bash}
+    name=${name%.sh}
+    [[ ' '$_omb_module_loaded' ' == *" $type:$name "* ]] && continue
+    _omb_module_loaded="$_omb_module_loaded $type:$name"
+
+    local -a locations=()
+    case $type in
+    lib)        locations=({"$OSH_CUSOM","$OSH"}/lib/"$name".{bash,sh}) ;;
+    plugin)     locations=({"$OSH_CUSOM","$OSH"}/plugins/"$name".plugin.{bash,sh}) ;;
+    alias)      locations=({"$OSH_CUSOM","$OSH"}/aliases/"$name".alias.{bash,sh}) ;;
+    completion) locations=({"$OSH_CUSOM","$OSH"}/completions/"$name".completion.{bash,sh}) ;;
+    theme)      locations=({"$OSH_CUSOM"{,/themes},"$OSH"/themes}/"$name"/"$name".theme.{bash,sh}) ;;
+    *)
+      echo "oh-my-bash (package_require): unknown package type '$type'." >&2
+      status=2
+      continue ;;
+    esac
+
+    local path
+    for path in "${locations[@]}"; do
+      if [[ -f $path ]]; then
+        files+=("$path")
+        continue 2
+      fi
+    done
+
+    echo "oh-my-bash (package_require): package '$type:$name' not found." >&2
+    status=127
+  done
+
+  if ((status==0)); then
+    local path
+    for path in "${files[@]}"; do
+      source "$path" || status=$?
+    done
+  fi
+
+  return "$status"
+}
+
+_omb_module_require_lib()        { _omb_module_require "${@/#/lib:}"; }
+_omb_module_require_plugin()     { _omb_module_require "${@/#/plugin:}"; }
+_omb_module_require_alias()      { _omb_module_require "${@/#/alias:}"; }
+_omb_module_require_completion() { _omb_module_require "${@/#/completion:}"; }
+_omb_module_require_theme()      { _omb_module_require "${@/#/theme:}"; }
 
 # Load all of the config files in ~/.oh-my-bash/lib that end in .sh
 # TIP: Add files you don't want in git to .gitignore
-for config_file in $OSH/lib/*.sh; do
-  custom_config_file="${OSH_CUSTOM}/lib/$(basename "${config_file}")"
-  [ -f "${custom_config_file}" ] && config_file=${custom_config_file}
-  source $config_file
-done
+_omb_module_require_lib utils
+_omb_module_require_lib omb-deprecate
+_omb_util_glob_expand _omb_init_files '{"$OSH","$OSH_CUSOM"}/lib/*.sh'
+_omb_init_files=("${_omb_init_files[@]##*/}")
+_omb_init_files=("${_omb_init_files[@]%.sh}")
+_omb_module_require_lib "${_omb_init_files[@]}"
+unset -v _omb_init_files
 
 # Figure out the SHORT hostname
 if [[ "$OSTYPE" = darwin* ]]; then
@@ -42,66 +93,41 @@ else
 fi
 
 # Load all of the plugins that were defined in ~/.bashrc
-for plugin in ${plugins[@]}; do
-  if [ -f $OSH_CUSTOM/plugins/$plugin/$plugin.plugin.sh ]; then
-    source $OSH_CUSTOM/plugins/$plugin/$plugin.plugin.sh
-  elif [ -f $OSH/plugins/$plugin/$plugin.plugin.sh ]; then
-    source $OSH/plugins/$plugin/$plugin.plugin.sh
-  fi
-done
+_omb_module_require_plugin ${plugins[@]}
 
 # Load all of the aliases that were defined in ~/.bashrc
-for alias in ${aliases[@]}; do
-  if [ -f $OSH_CUSTOM/aliases/$alias.aliases.sh ]; then
-    source $OSH_CUSTOM/aliases/$alias.aliases.sh
-  elif [ -f $OSH/aliases/$alias.aliases.sh ]; then
-    source $OSH/aliases/$alias.aliases.sh
-  fi
-done
+_omb_module_require_alias ${aliases[@]}
 
 # Load all of the completions that were defined in ~/.bashrc
-for completion in ${completions[@]}; do
-  if [ -f $OSH_CUSTOM/completions/$completion.completion.sh ]; then
-    source $OSH_CUSTOM/completions/$completion.completion.sh
-  elif [ -f $OSH/completions/$completion.completion.sh ]; then
-    source $OSH/completions/$completion.completion.sh
-  fi
-done
+_omb_module_require_completion ${completions[@]}
 
 # Load all of your custom configurations from custom/
-for config_file in $OSH_CUSTOM/*.sh; do
-  if [ -f $config_file ]; then
-    source $config_file
-  fi
+_omb_util_glob_expand _omb_init_files '"$OSH_CUSTOM"/*.{sh,bash}'
+for _omb_init_file in "${_omb_init_files[@]}"; do
+  [[ -f $_omb_init_file ]] &&
+    source "$_omb_init_file"
 done
-unset config_file
+unset -v _omb_init_files _omb_init_file
 
 # Load colors first so they can be use in base theme
 source "${OSH}/themes/colours.theme.sh"
 source "${OSH}/themes/base.theme.sh"
 
 # Load the theme
-if [ "$OSH_THEME" = "random" ]; then
-  themes=($OSH/themes/*/*theme.sh)
-  N=${#themes[@]}
-  ((N=(RANDOM%N)))
-  RANDOM_THEME=${themes[$N]}
-  source "$RANDOM_THEME"
-  echo "[oh-my-bash] Random theme '$RANDOM_THEME' loaded..."
-else
-  if [ ! "$OSH_THEME" = ""  ]; then
-    if [ -f "$OSH_CUSTOM/$OSH_THEME/$OSH_THEME.theme.sh" ]; then
-      source "$OSH_CUSTOM/$OSH_THEME/$OSH_THEME.theme.sh"
-    elif [ -f "$OSH_CUSTOM/themes/$OSH_THEME/$OSH_THEME.theme.sh" ]; then
-      source "$OSH_CUSTOM/themes/$OSH_THEME/$OSH_THEME.theme.sh"
-    else
-      source "$OSH/themes/$OSH_THEME/$OSH_THEME.theme.sh"
-    fi
+if [[ $OSH_THEME == random ]]; then
+  _omb_util_glob_expand _omb_init_files '"$OSH"/themes/*/*.theme.sh'
+  if ((${#_omb_init_files[@]})); then
+    _omb_init_file=${_omb_init_files[RANDOM%${#_omb_init_files[@]}]}
+    source "$_omb_init_file"
+    echo "[oh-my-bash] Random theme '$_omb_init_file' loaded..."
   fi
+  unset -v _omb_init_files _omb_init_file
+elif [[ $OSH_THEME ]]; then
+  _omb_module_require_theme "$OSH_THEME"
 fi
 
 if [[ $PROMPT ]]; then
-    export PS1="\["$PROMPT"\]"
+  export PS1="\["$PROMPT"\]"
 fi
 
 if ! _omb_util_command_exists '__git_ps1' ; then


### PR DESCRIPTION
We want to make use of our utility functions defined in a script file also from other script files. However, the loading order of script files matters for such a situation. Currently, we don't have a way to control the loading order. For example, in order to use `_omb_util_command_exists` (`lib/utils.sh`) from other script files in `lib/` as suggested in #239, we need to load `lib/utils.sh`  earlier than the other files.

We here introduce new functions `_omb_module_require{,_lib,_plugin,_alias,_completion,_theme}` that can be used to declare the dependencies in each module.
