### PR TITLE
Do not overwrite backup bashrc

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -4,7 +4,7 @@ function bash_stats() {
 }
 
 function uninstall_oh_my_bash() {
-  env OSH=$OSH sh $OSH/tools/uninstall.sh
+  source "$OSH"/tools/uninstall.sh
 }
 
 function upgrade_oh_my_bash() {

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -143,8 +143,9 @@ _omb_install_main() {
 
   printf "${BLUE}Looking for an existing bash config...${NORMAL}\n"
   if [[ -f ~/.bashrc || -h ~/.bashrc ]]; then
-    printf "${YELLOW}Found ~/.bashrc.${NORMAL} ${GREEN}Backing up to ~/.bashrc.pre-oh-my-bash${NORMAL}\n"
-    _omb_install_run mv ~/.bashrc ~/.bashrc.pre-oh-my-bash
+    local bashrc_backup=~/.bashrc.omb-backup-$(date +%Y%m%d%H%M%S)
+    printf "${YELLOW}Found ~/.bashrc.${NORMAL} ${GREEN}Backing up to $bashrc_backup${NORMAL}\n"
+    _omb_install_run mv ~/.bashrc "$bashrc_backup"
   fi
 
   printf "${BLUE}Using the Oh My Bash template file and adding it to ~/.bashrc${NORMAL}\n"

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -1,30 +1,77 @@
 #!/usr/bin/env bash
 
-read -r -p "Are you sure you want to remove Oh My Bash? [y/N] " confirmation
-if [ "$confirmation" != y ] && [ "$confirmation" != Y ]; then
-  echo "Uninstall cancelled"
-  exit
-fi
+_omb_uninstall_contains_omb() {
+  grep -qE '(source|\.)[[:space:]]+.*[/[:space:]]oh-my-bash\.sh' "$1" 2>/dev/null
+}
 
-echo "Removing ~/.oh-my-bash"
+# Find the latest bashrc that do not source oh-my-bash.sh
+_omb_uninstall_find_bashrc_original() {
+  _omb_uninstall_bashrc_original=
+  printf '%s\n' "Looking for original bash config..."
+  IFS='
+'
+  for _omb_uninstall_file in $(printf '%s\n' ~/.bashrc.omb-backup-?????????????? | sort -r) ~/.bashrc.pre-oh-my-bash; do
+    [ -f "$_omb_uninstall_file" ] || [ -h "$_omb_uninstall_file" ] || continue
+    _omb_uninstall_contains_omb "$_omb_uninstall_file" && continue
+    _omb_uninstall_bashrc_original=$_omb_uninstall_file
+    break
+  done
+  unset _omb_uninstall_file
+  IFS=' 	
+'
+  if [ -n "$_omb_uninstall_bashrc_original" ]; then
+    printf '%s\n' "-> Found at '$_omb_uninstall_bashrc_original'."
+  else
+    printf '%s\n' "-> Not found."
+  fi
+}
+
+read -r -p "Are you sure you want to remove Oh My Bash? [y/N] " _omb_uninstall_confirmation
+if [ "$_omb_uninstall_confirmation" != y ] && [ "$_omb_uninstall_confirmation" != Y ]; then
+  printf '%s\n' "Uninstall cancelled"
+  unset _omb_uninstall_confirmation
+  return 0 2>/dev/null || exit 0
+fi
+unset _omb_uninstall_confirmation
+
 if [ -d ~/.oh-my-bash ]; then
+  printf '%s\n' "Removing ~/.oh-my-bash"
   rm -rf ~/.oh-my-bash
 fi
 
-echo "Looking for original bash config..."
-if [ -f ~/.bashrc.pre-oh-my-bash ] || [ -h ~/.bashrc.pre-oh-my-bash ]; then
-  echo "Found ~/.bashrc.pre-oh-my-bash -- Restoring to ~/.bashrc";
+_omb_uninstall_bashrc_original=
+_omb_uninstall_find_bashrc_original
 
-  if [ -f ~/.bashrc ] || [ -h ~/.bashrc ]; then
-    bashrc_SAVE=".bashrc.omb-uninstalled-$(date +%Y%m%d%H%M%S)";
-    echo "Found ~/.bashrc -- Renaming to ~/${bashrc_SAVE}";
-    mv ~/.bashrc ~/"${bashrc_SAVE}";
+if ! _omb_uninstall_contains_omb ~/.bashrc; then
+  printf '%s\n' "uninstall: Oh-my-bash does not seem to be installed in .bashrc." >&2
+  if [ -n "$_omb_uninstall_bashrc_original" ]; then
+    printf '%s\n' "uninstall: The original config was found at '$_omb_uninstall_bashrc_original'." >&2
   fi
-
-  mv ~/.bashrc.pre-oh-my-bash ~/.bashrc;
-  exec bash; source ~/.bashrc
-
-  echo "Your original bash config was restored. Please restart your session."
+  printf '%s\n' "uninstall: Canceled." >&2
+  unset _omb_uninstall_bashrc_original
+  return 1 2>/dev/null || exit 1
 fi
 
+_omb_uninstall_bashrc_uninstalled=
+if [ -e ~/.bashrc ] || [ -h ~/.bashrc ]; then
+  _omb_uninstall_bashrc_uninstalled=".bashrc.omb-uninstalled-$(date +%Y%m%d%H%M%S)";
+  printf '%s\n' "Found ~/.bashrc -- Renaming to ~/${_omb_uninstall_bashrc_uninstalled}";
+  mv ~/.bashrc ~/"${_omb_uninstall_bashrc_uninstalled}";
+fi
+
+if [ -n "$_omb_uninstall_bashrc_original" ]; then
+  printf '%s\n' "Found $_omb_uninstall_bashrc_original -- Restoring to ~/.bashrc";
+  mv "$_omb_uninstall_bashrc_original" ~/.bashrc;
+  printf '%s\n' "Your original bash config was restored. Please restart your session."
+else
+  sed '/oh-my-bash\.sh/s/^/: #/' ~/"${_omb_uninstall_bashrc_uninstalled:-.bashrc}" >| ~/.bashrc.omb-temp && \
+    mv ~/.bashrc.omb-temp ~/.bashrc
+fi
+
+unset _omb_uninstall_bashrc_original
+unset _omb_uninstall_bashrc_uninstalled
+
 echo "Thanks for trying out Oh My Bash. It has been uninstalled."
+case $- in
+*i*) exec bash; source ~/.bashrc ;;
+esac

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -25,13 +25,6 @@ if [ -f ~/.bashrc.pre-oh-my-bash ] || [ -h ~/.bashrc.pre-oh-my-bash ]; then
   exec bash; source ~/.bashrc
 
   echo "Your original bash config was restored. Please restart your session."
-else
-  if hash chsh >/dev/null 2>&1; then
-    echo "Switching back to bash"
-    chsh -s /bin/bash
-  else
-    echo "You can edit /etc/passwd to switch your default shell back to bash"
-  fi
 fi
 
 echo "Thanks for trying out Oh My Bash. It has been uninstalled."


### PR DESCRIPTION
This fixes the issue reported at #115 and #267. We should not overwrite the existing backup file. In this PR, I take the approach suggested by @alexpfx in #115; The backup filename now contains the timestamp. Also, in recovering the original bashrc, we search for the latest backed-up `.bashrc` that does not contain `source oh-my-bash.sh`. Additionally, the code of `chsh -s bash` in uninstallation, which makes sense only for `oh-my-zsh`, has been removed.

----
Resolve #267 / Resolve #115