### PR TITLE
fixing typo of OSH_CUSOM => OSH_CUSTOM

### DIFF
--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -35,11 +35,11 @@ _omb_module_require() {
 
     local -a locations=()
     case $type in
-    lib)        locations=({"$OSH_CUSOM","$OSH"}/lib/"$name".{bash,sh}) ;;
-    plugin)     locations=({"$OSH_CUSOM","$OSH"}/plugins/"$name"/"$name".plugin.{bash,sh}) ;;
-    alias)      locations=({"$OSH_CUSOM","$OSH"}/aliases/"$name".aliases.{bash,sh}) ;;
-    completion) locations=({"$OSH_CUSOM","$OSH"}/completions/"$name".completion.{bash,sh}) ;;
-    theme)      locations=({"$OSH_CUSOM"{,/themes},"$OSH"/themes}/"$name"/"$name".theme.{bash,sh}) ;;
+    lib)        locations=({"$OSH_CUSTOM","$OSH"}/lib/"$name".{bash,sh}) ;;
+    plugin)     locations=({"$OSH_CUSTOM","$OSH"}/plugins/"$name"/"$name".plugin.{bash,sh}) ;;
+    alias)      locations=({"$OSH_CUSTOM","$OSH"}/aliases/"$name".aliases.{bash,sh}) ;;
+    completion) locations=({"$OSH_CUSTOM","$OSH"}/completions/"$name".completion.{bash,sh}) ;;
+    theme)      locations=({"$OSH_CUSTOM"{,/themes},"$OSH"/themes}/"$name"/"$name".theme.{bash,sh}) ;;
     *)
       echo "oh-my-bash (module_require): unknown package type '$type'." >&2
       status=2
@@ -78,7 +78,7 @@ _omb_module_require_theme()      { _omb_module_require "${@/#/theme:}"; }
 # TIP: Add files you don't want in git to .gitignore
 _omb_module_require_lib utils
 _omb_module_require_lib omb-deprecate
-_omb_util_glob_expand _omb_init_files '{"$OSH","$OSH_CUSOM"}/lib/*.sh'
+_omb_util_glob_expand _omb_init_files '{"$OSH","$OSH_CUSTOM"}/lib/*.sh'
 _omb_init_files=("${_omb_init_files[@]##*/}")
 _omb_init_files=("${_omb_init_files[@]%.sh}")
 _omb_module_require_lib "${_omb_init_files[@]}"


### PR DESCRIPTION
recently I started getting errors where oh-my-bash couldn't find my custom OSH_CUSTOM path.  I believe it is because of this accidental typo of OSH_CUSTOM as OSH_CUSOM 