### PR TITLE
Fix exporting LESSOPEN

### DIFF
--- a/lib/bourne-shell.sh
+++ b/lib/bourne-shell.sh
@@ -3,7 +3,17 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 
 # make less more friendly for non-text input files, see lesspipe(1)
-[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+if [ -z "${LESSOPEN}" ];then
+  if [ -f /etc/gentoo-release ]; then
+    export LESSOPEN="|lesspipe %s"
+  else
+    if [ -x /usr/bin/lesspipe ]; then
+      eval "$(SHELL=/bin/sh /usr/bin/lesspipe)"
+    elif [ -x /usr/bin/lesspipe.sh ]; then
+      eval "$(SHELL=/bin/sh /usr/bin/lesspipe.sh)"
+    fi
+  fi
+fi
 
 # set variable identifying the chroot you work in (used in the prompt below)
 if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then


### PR DESCRIPTION
Do not use eval and export LESSOPEN directly only when is empty.
This will prevent problems on distributions using different lesspipe
and/or defining LESSOPEN variable on their own.

Issue #46 #69

----

Fixes #46 / Fixes #69 / Fixes #296