### PR TITLE
Upgrade/Uninstall/Install OMB in the interactive shell process

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -8,7 +8,7 @@ function uninstall_oh_my_bash() {
 }
 
 function upgrade_oh_my_bash() {
-  env OSH=$OSH sh $OSH/tools/upgrade.sh
+  source "$OSH"/tools/upgrade.sh
 }
 
 function take() {

--- a/lib/history.sh
+++ b/lib/history.sh
@@ -26,7 +26,7 @@ shopt -s histverify
 shopt -s lithist
 
 # Record each line as it gets issued
-PROMPT_COMMAND='history -a'
+_omb_util_add_prompt_command 'history -a'
 
 # Huge history. Doesn't appear to slow things down, so why not?
 HISTSIZE=500000

--- a/lib/omb-deprecate.sh
+++ b/lib/omb-deprecate.sh
@@ -32,3 +32,12 @@ _omb_util_defun_deprecate 20000 e_warning   _omb_log_warning
 _omb_util_defun_deprecate 20000 e_underline _omb_log_underline
 _omb_util_defun_deprecate 20000 e_bold      _omb_log_bold
 _omb_util_defun_deprecate 20000 e_note      _omb_log_note
+
+# themes/*
+_omb_util_defun_deprecate 20000 prompt_command  _omb_theme_PROMPT_COMMAND
+_omb_util_defun_deprecate 20000 prompt          _omb_theme_PROMPT_COMMAND
+_omb_util_defun_deprecate 20000 prompt_setter   _omb_theme_PROMPT_COMMAND
+_omb_util_defun_deprecate 20000 pure_setter     _omb_theme_PROMPT_COMMAND # pure, gallifrey
+_omb_util_defun_deprecate 20000 dulcie_setter   _omb_theme_PROMPT_COMMAND # dulcie
+_omb_util_defun_deprecate 20000 _brainy_setter  _omb_theme_PROMPT_COMMAND # brainy
+_omb_util_defun_deprecate 20000 set_bash_prompt _omb_theme_PROMPT_COMMAND # agnoster

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -250,6 +250,17 @@ else
   }
 fi
 
+_omb_util_unload_hook=()
+_omb_util_unload() {
+  local hook
+  for hook in "${_omb_util_unload_hook[@]}"; do
+    eval -- "$hook"
+  done
+}
+
+_omb_util_original_PS1=$PS1
+_omb_util_unload_hook+=('PS1=$_omb_util_original_PS1')
+
 _omb_util_prompt_command=()
 _omb_util_prompt_command_hook() {
   local status=$? lastarg=$_ hook
@@ -259,8 +270,9 @@ _omb_util_prompt_command_hook() {
   done
 }
 
-: "${_omb_util_prompt_command_setup=}"
+_omb_util_unload_hook+=('_omb_util_prompt_command=()')
 
+: "${_omb_util_prompt_command_setup=}"
 _omb_util_add_prompt_command() {
   local other
   for other in "${_omb_util_prompt_command[@]}"; do

--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -11,8 +11,8 @@ case $- in
 esac
 
 # Check for updates on initial load...
-if [ "$DISABLE_AUTO_UPDATE" != "true" ]; then
-  env OSH="$OSH" DISABLE_UPDATE_PROMPT="$DISABLE_UPDATE_PROMPT" bash -f "$OSH"/tools/check_for_upgrade.sh
+if [[ $DISABLE_AUTO_UPDATE != true ]]; then
+  source "$OSH"/tools/check_for_upgrade.sh
 fi
 
 # Initializes Oh My Bash

--- a/themes/90210/90210.theme.sh
+++ b/themes/90210/90210.theme.sh
@@ -10,8 +10,8 @@ GIT_THEME_PROMPT_PREFIX=" ${green}|"
 GIT_THEME_PROMPT_SUFFIX="${green}|"
 
 # Nicely formatted terminal prompt
-function prompt_command(){
+function _omb_theme_PROMPT_COMMAND(){
   export PS1="\n${bold_black}[${blue}\@${bold_black}]-${bold_black}[${green}\u${yellow}@${green}\h${bold_black}]-${bold_black}[${purple}\w${bold_black}]-$(scm_prompt_info)\n${reset_color}\$ "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -303,7 +303,7 @@ __command_rprompt() {
     done
     [ -z "$times" ] || printf "%${n}s$times\\r" ''
 }
-# PROMPT_COMMAND=__command_rprompt
+# _omb_util_add_prompt_command __command_rprompt
 
 # this doens't wrap code in \[ \]
 ansi_r() {
@@ -414,7 +414,7 @@ build_prompt() {
 # this doesn't work... new model: create a prompt via a PR variable and
 # use that.
 
-set_bash_prompt() {
+_omb_theme_PROMPT_COMMAND() {
     RETVAL=$?
     PR=""
     PRIGHT=""
@@ -426,5 +426,4 @@ set_bash_prompt() {
     #     PS1='\[$(tput sc; printf "%*s" $COLUMNS "$PRIGHT"; tput rc)\]'$PR
     PS1=$PR
 }
-
-PROMPT_COMMAND=set_bash_prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/axin/axin.theme.sh
+++ b/themes/axin/axin.theme.sh
@@ -33,10 +33,10 @@ else
     RESET="\033[m"
 fi
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
   PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]@ \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\[$SCM_THEME_PROMPT_PREFIX\]$(clock_prompt) \[$PURPLE\]\$(scm_prompt_info) \n\$ \[$RESET\]"
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"${white}"}
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/bakke/bakke.theme.sh
+++ b/themes/bakke/bakke.theme.sh
@@ -12,11 +12,11 @@ GIT_THEME_PROMPT_SUFFIX="${green}|"
 RVM_THEME_PROMPT_PREFIX="|"
 RVM_THEME_PROMPT_SUFFIX="|"
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(_omb_prompt_print_ruby_env) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
     #PS1="\n${purple}\h: ${reset_color} ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
     #PS1="\n${cyan}\h: ${reset_color} ${yellow}\w\n${red}$(scm_char)${red}$(scm_prompt_info) ${green}→${reset_color} "
     PS1="\n${cyan}\h: ${reset_color} ${yellow}\w ${green}$(scm_prompt_info)\n${reset_color}→ "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/binaryanomaly/binaryanomaly.theme.sh
+++ b/themes/binaryanomaly/binaryanomaly.theme.sh
@@ -66,7 +66,7 @@ __ps_time() {
   echo "$(clock_prompt)${normal}\n"
 }
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
   ps_reboot="${bright_yellow}$(show_reboot_required)${normal}\n"
 
   ps_username="$(set_user_color)\u${normal}"
@@ -98,4 +98,4 @@ SCM_GIT_CHAR="${green}±${light_grey}"
 SCM_SVN_CHAR="${bold_cyan}⑆${light_grey}"
 SCM_HG_CHAR="${bold_red}☿${light_grey}"
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/bobby-python/bobby-python.theme.sh
+++ b/themes/bobby-python/bobby-python.theme.sh
@@ -11,9 +11,9 @@ GIT_THEME_PROMPT_SUFFIX="${green}|"
 
 CONDAENV_THEME_PROMPT_SUFFIX="|"
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(_omb_prompt_print_ruby_env) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
     PS1="\n${yellow}$(python_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/bobby/bobby.theme.sh
+++ b/themes/bobby/bobby.theme.sh
@@ -21,7 +21,7 @@ __bobby_clock() {
   fi
 }
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(_omb_prompt_print_ruby_env) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
     PS1="\n$(battery_char) $(__bobby_clock)${yellow}$(_omb_prompt_print_ruby_env) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_prompt_char_info) ${green}→${reset_color} "
 }
@@ -31,4 +31,4 @@ THEME_CLOCK_CHAR_COLOR=${THEME_CLOCK_CHAR_COLOR:-"$red"}
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$bold_cyan"}
 THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:-"%Y-%m-%d %H:%M:%S"}
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/brainy/brainy.theme.sh
+++ b/themes/brainy/brainy.theme.sh
@@ -285,11 +285,11 @@ __brainy_ps2() {
 	printf "%s%s%s" "${color}" "${__BRAINY_PROMPT_CHAR_PS2}  " "${normal}"
 }
 
-_brainy_prompt() {
+_omb_theme_PROMPT_COMMAND() {
     exitcode="$?"
 
     PS1="$(__brainy_ps1)"
     PS2="$(__brainy_ps2)"
 }
 
-_omb_util_add_prompt_command _brainy_prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/brunton/brunton.theme.sh
+++ b/themes/brunton/brunton.theme.sh
@@ -26,11 +26,11 @@ scm_prompt() {
 	fi
 }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
   PS1="${white}${background_blue} \u${normal}${background_blue}@${red}${background_blue}\h $(clock_prompt) ${reset_color}${normal} $(battery_charge)\n${bold_black}${background_white} \w ${normal}$(scm_prompt)$(is_vim_shell)\n${white}>${normal} "
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$blue$background_white"}
 THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:-" %H:%M:%S"}
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/candy/candy.theme.sh
+++ b/themes/candy/candy.theme.sh
@@ -1,10 +1,10 @@
 #! bash oh-my-bash.module
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     PS1="${green}\u@\h $(clock_prompt) ${reset_color}${white}\w${reset_color}$(scm_prompt_info)${blue} →${bold_blue} ${reset_color} ";
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$blue"}
 THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:-"%I:%M:%S"}
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/clean/clean.theme.sh
+++ b/themes/clean/clean.theme.sh
@@ -10,7 +10,7 @@ ZSH_THEME_GIT_PROMPT_DIRTY="${bold_red}✗"
 export LSCOLORS="Gxfxcxdxbxegedabagacad"
 export LS_COLORS='no=00:fi=00:di=01;34:ln=00;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=41;33;01:ex=00;32:*.cmd=00;32:*.exe=01;32:*.com=01;32:*.bat=01;32:*.btm=01;32:*.dll=01;32:*.tar=00;31:*.tbz=00;31:*.tgz=00;31:*.rpm=00;31:*.deb=00;31:*.arj=00;31:*.taz=00;31:*.lzh=00;31:*.lzma=00;31:*.zip=00;31:*.zoo=00;31:*.z=00;31:*.Z=00;31:*.gz=00;31:*.bz2=00;31:*.tb2=00;31:*.tz2=00;31:*.tbz2=00;31:*.avi=01;35:*.bmp=01;35:*.fli=01;35:*.gif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mng=01;35:*.mov=01;35:*.mpg=01;35:*.pcx=01;35:*.pbm=01;35:*.pgm=01;35:*.png=01;35:*.ppm=01;35:*.tga=01;35:*.tif=01;35:*.xbm=01;35:*.xpm=01;35:*.dl=01;35:*.gl=01;35:*.wmv=01;35:*.aiff=00;32:*.au=00;32:*.mid=00;32:*.mp3=00;32:*.ogg=00;32:*.voc=00;32:*.wav=00;32:'
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
 
     if [ "$(whoami)" = root ]; then no_color=$red; else no_color=$white; fi
 
@@ -18,4 +18,4 @@ function prompt_command() {
     RPROMPT='[\t]'
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/cooperkid/cooperkid.theme.sh
+++ b/themes/cooperkid/cooperkid.theme.sh
@@ -17,7 +17,7 @@ function git_short_sha() {
   SHA=$(git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
 }
 
-function prompt() {
+function _omb_theme_PROMPT_COMMAND() {
     local return_status=""
     local ruby="${red}$(_omb_prompt_print_ruby_env)${reset_color}"
     local user_host="${green}\h @ \w${reset_color}"
@@ -28,4 +28,4 @@ function prompt() {
     PS1="\n${user_host}${prompt_symbol}${ruby} ${git_branch} ${return_status}\n${prompt_char}"
 }
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/cupcake/cupcake.theme.sh
+++ b/themes/cupcake/cupcake.theme.sh
@@ -62,10 +62,10 @@ function winname {
 # PROMPT OUTPUT ===============================================================
 
 # Displays the current prompt
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
   PS1="\n${icon_start}$(_omb_prompt_print_python_venv)${icon_user}${bold_red}\u${normal}${icon_host}${bold_cyan}\h${normal}${icon_directory}${bold_purple}\W${normal}\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on ${icon_branch}  \")${white}$(scm_prompt_info)${normal}\n${icon_end}"
   PS2="${icon_end}"
 }
 
 # Runs prompt (this bypasses oh-my-bash $PROMPT setting)
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/demula/demula.theme.sh
+++ b/themes/demula/demula.theme.sh
@@ -91,7 +91,7 @@ safe_battery_charge() {
 }
 
 # -------------------------------------------------------------- PROMPT OUTPUT
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
   local LAST_COMMAND_FAILED=$(mitsuhikos_lastcommandfailed)
   local SAVE_CURSOR='\033[s'
   local RESTORE_CURSOR='\033[u'
@@ -126,4 +126,4 @@ ${D_INTERMEDIATE_COLOR}$ ${D_DEFAULT_COLOR}"
 }
 
 # Runs prompt (this bypasses oh-my-bash $PROMPT setting)
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/doubletime/doubletime.theme.sh
+++ b/themes/doubletime/doubletime.theme.sh
@@ -39,7 +39,7 @@ doubletime_scm_prompt() {
   fi
 }
 
-function prompt_setter() {
+function _omb_theme_PROMPT_COMMAND() {
   # Save history
   history -a
   history -c
@@ -51,7 +51,7 @@ $(doubletime_scm_prompt)$reset_color $ "
   PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 git_prompt_status() {
   local git_status_output

--- a/themes/doubletime_multiline/doubletime_multiline.theme.sh
+++ b/themes/doubletime_multiline/doubletime_multiline.theme.sh
@@ -2,7 +2,7 @@
 
 source "$OSH/themes/doubletime/doubletime.theme.sh"
 
-function prompt_setter() {
+function _omb_theme_PROMPT_COMMAND() {
   # Save history
   history -a
   history -c
@@ -15,4 +15,4 @@ $(doubletime_scm_prompt)$reset_color $ "
   PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/doubletime_multiline_pyonly/doubletime_multiline_pyonly.theme.sh
+++ b/themes/doubletime_multiline_pyonly/doubletime_multiline_pyonly.theme.sh
@@ -2,7 +2,7 @@
 
 source "$OSH/themes/doubletime/doubletime.theme.sh"
 
-function prompt_setter() {
+function _omb_theme_PROMPT_COMMAND() {
   # Save history
   history -a
   history -c
@@ -15,4 +15,4 @@ $(doubletime_scm_prompt)$reset_color $ "
   PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/dulcie/dulcie.theme.sh
+++ b/themes/dulcie/dulcie.theme.sh
@@ -23,7 +23,7 @@ dulcie_background() {
   echo -en "\[\e[48;5;${1}m\]"
 }
 
-dulcie_prompt() {
+_omb_theme_PROMPT_COMMAND() {
   color_user_root=$(dulcie_color 169)
   color_user_nonroot="${green}"
   color_host_local=$(dulcie_color 230)
@@ -95,4 +95,4 @@ dulcie_prompt() {
   PS1="${PS1}${DULCIE_PROMPTCHAR} "
 }
 
-_omb_util_add_prompt_command dulcie_prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/duru/duru.theme.sh
+++ b/themes/duru/duru.theme.sh
@@ -17,8 +17,8 @@ last_two_dirs() {
   pwd|rev|awk -F / '{print $1,$2}'|rev|sed s_\ _/_|sed "s|$(sed 's,\/,,'<<<$HOME)|~|g"
 }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
   PS1="${yellow}# ${reset_color}$(last_two_dirs)$(scm_prompt_info)${reset_color}$(venv)${reset_color} ${cyan}\n> ${reset_color}"
 }
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/emperor/emperor.theme.sh
+++ b/themes/emperor/emperor.theme.sh
@@ -33,10 +33,10 @@ __emperor_clock() {
   clock_prompt
 }
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     PS1="\n$(__emperor_clock)${purple}\h ${reset_color}in ${prompt_color}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
 THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:-"%H "}
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/envy/envy.theme.sh
+++ b/themes/envy/envy.theme.sh
@@ -9,8 +9,8 @@ GIT_THEME_PROMPT_CLEAN=" ${bold_green}✓"
 GIT_THEME_PROMPT_PREFIX=" ${green}|"
 GIT_THEME_PROMPT_SUFFIX="${green}|"
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     PS1="\n${yellow}$(_omb_prompt_print_ruby_env) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/font/font.theme.sh
+++ b/themes/font/font.theme.sh
@@ -37,7 +37,7 @@ THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:-"%I:%M:%S"}
 VIRTUALENV_THEME_PROMPT_PREFIX='('
 VIRTUALENV_THEME_PROMPT_SUFFIX=') '
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     # This needs to be first to save last command return code
     local RC="$?"
 
@@ -58,4 +58,4 @@ function prompt_command() {
     PS1="$(clock_prompt)$python_venv${hostname} ${bold_cyan}\W $(scm_prompt_char_info)${ret_status}→ ${normal}"
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/gallifrey/gallifrey.theme.sh
+++ b/themes/gallifrey/gallifrey.theme.sh
@@ -24,7 +24,7 @@ scm_prompt() {
     fi
 }
 
-pure_prompt() {
+_omb_theme_PROMPT_COMMAND() {
     ps_host="${green}\h${normal}";
     ps_user_mark="${bold}\$${normal}";
     ps_root_mark="${normal}§"
@@ -39,4 +39,4 @@ pure_prompt() {
     esac
 }
 
-_omb_util_add_prompt_command pure_prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/garo/garo.theme.sh
+++ b/themes/garo/garo.theme.sh
@@ -31,7 +31,7 @@ export SCM_GIT_SHOW_MINIMAL_INFO=true
 export VIRTUALENV_THEME_PROMPT_PREFIX='('
 export VIRTUALENV_THEME_PROMPT_SUFFIX=') '
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     # This needs to be first to save last command return code
     local RC="$?"
 
@@ -52,4 +52,4 @@ function prompt_command() {
     PS1="$python_venv${hostname} ${bold_cyan}\w $(scm_prompt_char_info)${ret_status}→ ${normal}"
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/half-life/half-life.theme.sh
+++ b/themes/half-life/half-life.theme.sh
@@ -11,7 +11,7 @@ _omb_theme_half_way_prompt_scm() {
   fi
 }
 
-prompt_command() {
+_omb_theme_PROMPT_COMMAND() {
   local ps_username="${purple}\u${normal}"
   local ps_path="${green}\w${normal}"
   local ps_user_mark="${orange}λ${normal}"
@@ -19,4 +19,4 @@ prompt_command() {
   PS1="$ps_username in $ps_path$(_omb_theme_half_way_prompt_scm) $ps_user_mark "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/hawaii50/hawaii50.theme.sh
+++ b/themes/hawaii50/hawaii50.theme.sh
@@ -181,7 +181,7 @@ function limited_pwd() {
 }
 
 # Displays the current prompt
-function prompt() {
+function _omb_theme_PROMPT_COMMAND() {
     local UC=$USER_COLOR
     ((UID == 0)) && UC=$SUPERUSER_COLOR
 
@@ -194,4 +194,4 @@ function prompt() {
     PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/iterate/iterate.theme.sh
+++ b/themes/iterate/iterate.theme.sh
@@ -33,7 +33,7 @@ function git_prompt_info {
 }
 
 LAST_PROMPT=""
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     local new_PS1="${bold_cyan}$(scm_char)${yellow}$(_omb_prompt_print_ruby_env)${green}\w $(scm_prompt_info)"
     local new_prompt=$(PS1="$new_PS1" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
 
@@ -48,4 +48,4 @@ function prompt_command() {
     PS1="${new_PS1}${green}${wrap_char}→${reset_color} "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/kitsune/kitsune.theme.sh
+++ b/themes/kitsune/kitsune.theme.sh
@@ -7,7 +7,7 @@
 
 _omb_module_require plugin:battery
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
   local status=$?
 
   # added TITLEBAR for updating the tab and window titles with the pwd
@@ -40,4 +40,4 @@ SCM_THEME_PROMPT_PREFIX="${bold_cyan}("
 SCM_THEME_PROMPT_SUFFIX="${bold_cyan})${reset_color}"
 
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/luan/luan.theme.sh
+++ b/themes/luan/luan.theme.sh
@@ -13,7 +13,7 @@ GIT_THEME_PROMPT_SUFFIX="${normal})"
 RVM_THEME_PROMPT_PREFIX=""
 RVM_THEME_PROMPT_SUFFIX=""
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     dtime="$(clock_prompt)"
     user_host="${green}\u@${cyan}\h${normal}"
     current_dir="${bold_blue}\w${normal}"
@@ -30,4 +30,4 @@ function prompt_command() {
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$yellow"}
 THEME_CLOCK_FORMAT=${THEME_TIME_FORMAT:-"%I:%M:%S "}
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/mairan/mairan.theme.sh
+++ b/themes/mairan/mairan.theme.sh
@@ -99,7 +99,7 @@ my_ve(){
     echo "";
     }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
 
     my_ps_host="$BOLD$ORANGE\h${normal}";
     # yes, these are the the same for now ...
@@ -128,4 +128,4 @@ PS2="└─▪ "
 
 
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/mbriggs/mbriggs.theme.sh
+++ b/themes/mbriggs/mbriggs.theme.sh
@@ -17,7 +17,7 @@ function git_short_sha() {
   SHA=$(git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
 }
 
-function prompt() {
+function _omb_theme_PROMPT_COMMAND() {
     local return_status=""
     local ruby="${red}$(_omb_prompt_print_ruby_env)${reset_color}"
     local user_host="${green}\h${reset_color}"
@@ -32,4 +32,4 @@ function prompt() {
     PS1="\n${n_commands} ${user_host} ${prompt_symbol} ${ruby} ${open}${current_path}${git_branch}${close}${return_status}\n${prompt_char}"
 }
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/minimal/minimal.theme.sh
+++ b/themes/minimal/minimal.theme.sh
@@ -5,8 +5,8 @@ SCM_THEME_PROMPT_SUFFIX="${cyan})"
 SCM_THEME_PROMPT_DIRTY=" ${red}✗"
 SCM_THEME_PROMPT_CLEAN=" ${green}✓"
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
   PS1="$(scm_prompt_info)${reset_color} ${cyan}\W${reset_color} "
 }
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/modern-t/modern-t.theme.sh
+++ b/themes/modern-t/modern-t.theme.sh
@@ -36,7 +36,7 @@ modern_scm_prompt() {
 	fi
 }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
 	if [ $? -ne 0 ]
 	then
 		# Yes, the indenting on these is weird, but it has to be like
@@ -54,4 +54,4 @@ PS2="└─▪ "
 
 
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/modern/modern.theme.sh
+++ b/themes/modern/modern.theme.sh
@@ -36,7 +36,7 @@ modern_scm_prompt() {
 	fi
 }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
 	if [ $? -ne 0 ]
 	then
 		# Yes, the indenting on these is weird, but it has to be like
@@ -54,4 +54,4 @@ PS2="└─▪ "
 
 
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/morris/morris.theme.sh
+++ b/themes/morris/morris.theme.sh
@@ -15,7 +15,7 @@ case $TERM in
 		;;
 esac
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
 	PS1="${TITLEBAR}[\u@\h \W $(scm_prompt_info)]\$ "
 }
 
@@ -26,4 +26,4 @@ SCM_THEME_PROMPT_PREFIX="${green}("
 SCM_THEME_PROMPT_SUFFIX="${green})${reset_color}"
 
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/n0qorg/n0qorg.theme.sh
+++ b/themes/n0qorg/n0qorg.theme.sh
@@ -5,11 +5,11 @@
 # host directory (branch*)»
 # for example:
 # ananas ~/Code/bash-it/themes (master*)»
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     PS1="${bold_blue}[$(hostname)]${normal} \w${normal} ${bold_white}[$(git_prompt_info)]${normal}» "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 ## git-theme
 # feel free to change git chars.

--- a/themes/nwinkler/nwinkler.theme.sh
+++ b/themes/nwinkler/nwinkler.theme.sh
@@ -23,7 +23,7 @@ function prompt_end() {
   echo -e "$PROMPT_END"
 }
 
-prompt_setter() {
+_omb_theme_PROMPT_COMMAND() {
   local exit_status=$?
   if [[ $exit_status -eq 0 ]]; then PROMPT_END=$PROMPT_END_CLEAN
     else PROMPT_END=$PROMPT_END_DIRTY
@@ -37,7 +37,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 SCM_THEME_PROMPT_DIRTY=" ${bold_red}✗${normal}"
 SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"

--- a/themes/nwinkler_random_colors/nwinkler_random_colors.theme.sh
+++ b/themes/nwinkler_random_colors/nwinkler_random_colors.theme.sh
@@ -90,7 +90,7 @@ function prompt_end() {
   echo -e "$PROMPT_END"
 }
 
-prompt_setter() {
+_omb_theme_PROMPT_COMMAND() {
   local exit_status=$?
   if [[ $exit_status -eq 0 ]]; then PROMPT_END=$PROMPT_END_CLEAN
     else PROMPT_END=$PROMPT_END_DIRTY
@@ -104,7 +104,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 SCM_THEME_PROMPT_DIRTY=" ${bold_red}✗${normal}"
 SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"

--- a/themes/pete/pete.theme.sh
+++ b/themes/pete/pete.theme.sh
@@ -1,6 +1,6 @@
 #! bash oh-my-bash.module
 
-prompt_setter() {
+_omb_theme_PROMPT_COMMAND() {
   # Save history
   history -a
   history -c
@@ -10,7 +10,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 SCM_THEME_PROMPT_DIRTY=" ✗"
 SCM_THEME_PROMPT_CLEAN=" ✓"

--- a/themes/powerline-multiline/powerline-multiline.theme.sh
+++ b/themes/powerline-multiline/powerline-multiline.theme.sh
@@ -50,4 +50,5 @@ IN_VIM_THEME_PROMPT_TEXT="vim"
 POWERLINE_LEFT_PROMPT=${POWERLINE_LEFT_PROMPT:="scm python_venv ruby cwd"}
 POWERLINE_RIGHT_PROMPT=${POWERLINE_RIGHT_PROMPT:="in_vim clock battery user_info"}
 
-_omb_util_add_prompt_command __powerline_prompt_command
+_omb_theme_PROMPT_COMMAND() { __powerline_prompt_command "$@"; }
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/powerline-naked/powerline-naked.theme.sh
+++ b/themes/powerline-naked/powerline-naked.theme.sh
@@ -49,4 +49,5 @@ IN_VIM_THEME_PROMPT_TEXT="vim"
 
 POWERLINE_PROMPT=${POWERLINE_PROMPT:="user_info scm python_venv ruby cwd"}
 
-_omb_util_add_prompt_command __powerline_prompt_command
+_omb_theme_PROMPT_COMMAND() { __powerline_prompt_command "$@"; }
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/powerline-plain/powerline-plain.theme.sh
+++ b/themes/powerline-plain/powerline-plain.theme.sh
@@ -45,4 +45,5 @@ IN_VIM_THEME_PROMPT_TEXT="vim"
 
 POWERLINE_PROMPT=${POWERLINE_PROMPT:="user_info scm python_venv ruby cwd"}
 
-_omb_util_add_prompt_command __powerline_prompt_command
+_omb_theme_PROMPT_COMMAND() { __powerline_prompt_command "$@"; }
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/powerline/powerline.theme.sh
+++ b/themes/powerline/powerline.theme.sh
@@ -48,4 +48,5 @@ IN_VIM_THEME_PROMPT_TEXT="vim"
 
 POWERLINE_PROMPT=${POWERLINE_PROMPT:="user_info scm python_venv ruby cwd"}
 
-_omb_util_add_prompt_command __powerline_prompt_command
+_omb_theme_PROMPT_COMMAND() { __powerline_prompt_command "$@"; }
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/primer/primer.theme.sh
+++ b/themes/primer/primer.theme.sh
@@ -1,11 +1,11 @@
 #! bash oh-my-bash.module
 
 # based of the candy theme, but minimized by odbol
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     PS1="$(clock_prompt) ${reset_color}${white}\w${reset_color}$(scm_prompt_info)${blue} →${bold_blue} ${reset_color} ";
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$blue"}
 THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:-"%I:%M:%S"}
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/pro/pro.theme.sh
+++ b/themes/pro/pro.theme.sh
@@ -15,8 +15,8 @@ function git_prompt_info {
   echo -e "$SCM_PREFIX$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
 }
 
-function prompt() {
+function _omb_theme_PROMPT_COMMAND() {
   PS1="\h: \W $(scm_prompt_info)${reset_color} $ "
 }
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/pure/pure.theme.sh
+++ b/themes/pure/pure.theme.sh
@@ -24,7 +24,7 @@ scm_prompt() {
     fi 
 }
 
-pure_prompt() {
+_omb_theme_PROMPT_COMMAND() {
     ps_host="${bold_blue}\h${normal}";
     ps_user="${green}\u${normal}";
     ps_user_mark="${green} $ ${normal}";
@@ -41,4 +41,4 @@ pure_prompt() {
     esac
 }
 
-_omb_util_add_prompt_command pure_prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/purity/purity.theme.sh
+++ b/themes/purity/purity.theme.sh
@@ -13,9 +13,9 @@ GIT_THEME_PROMPT_SUFFIX=" ${reset_color})"
 STATUS_THEME_PROMPT_BAD="${bold_red}❯${reset_color}${normal} "
 STATUS_THEME_PROMPT_OK="${bold_green}❯${reset_color}${normal} "
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     local ret_status="$( [ $? -eq 0 ] && echo -e "$STATUS_THEME_PROMPT_OK" || echo -e "$STATUS_THEME_PROMPT_BAD")"
     PS1="\n${blue}\w $(scm_prompt_info)\n${ret_status} "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/rainbowbrite/rainbowbrite.theme.sh
+++ b/themes/rainbowbrite/rainbowbrite.theme.sh
@@ -5,7 +5,7 @@
 # ± ~/path/to (branch ✓) $
 # in glorious red / blue / yellow color scheme
 
-prompt_setter() {
+_omb_theme_PROMPT_COMMAND() {
   # Save history
   history -a
   history -c
@@ -18,7 +18,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 SCM_NONE_CHAR='·'
 SCM_THEME_PROMPT_DIRTY=" ${red}✗"

--- a/themes/rana/rana.theme.sh
+++ b/themes/rana/rana.theme.sh
@@ -174,7 +174,7 @@ prompt_git() {
 }
 
 # -------------------------------------------------------------- PROMPT OUTPUT
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
   local LAST_COMMAND_FAILED=$(mitsuhikos_lastcommandfailed)
   local SAVE_CURSOR='\033[s'
   local RESTORE_CURSOR='\033[u'
@@ -211,4 +211,4 @@ ${D_INTERMEDIATE_COLOR}$ ${D_DEFAULT_COLOR}"
 }
 
 # Runs prompt (this bypasses oh-my-bash $PROMPT setting)
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/rjorgenson/rjorgenson.theme.sh
+++ b/themes/rjorgenson/rjorgenson.theme.sh
@@ -76,7 +76,7 @@ my_prompt_char() {
     fi
 }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
 
     my_ps_host="${STRING_COLOR}\h${normal}";
     my_ps_user="${STRING_COLOR}\u${normal}";
@@ -98,4 +98,4 @@ PS2="└─$(my_prompt_char)"
 
 
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/roderik/roderik.theme.sh
+++ b/themes/roderik/roderik.theme.sh
@@ -6,7 +6,7 @@ export GIT_PS1_SHOWSTASHSTATE=true
 
 export PROMPT_DIRTRIM=3
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     if [[ ${EUID} == 0 ]] ; then
         PS1="[$(clock_prompt)]${yellow}[${red}\u@\h ${green}\w${yellow}]${red}$(__git_ps1 "(%s)")${normal}\\$ "
     else
@@ -14,4 +14,4 @@ function prompt_command() {
     fi
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/sexy/sexy.theme.sh
+++ b/themes/sexy/sexy.theme.sh
@@ -40,8 +40,8 @@ parse_git_branch () {
   git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
 }
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
   PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")\[$PURPLE\]\$(parse_git_branch)\[$WHITE\]\n\$ \[$RESET\]"
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/simple/simple.theme.sh
+++ b/themes/simple/simple.theme.sh
@@ -12,7 +12,7 @@ case $TERM in
 	;;
 esac
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
 	PS1="${TITLEBAR}${orange}${reset_color}${green}\w${bold_blue}\[\$(scm_prompt_info)\]${normal} "
 }
 
@@ -22,4 +22,4 @@ SCM_THEME_PROMPT_CLEAN=" ✓"
 SCM_THEME_PROMPT_PREFIX="("
 SCM_THEME_PROMPT_SUFFIX=")"
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/sirup/sirup.theme.sh
+++ b/themes/sirup/sirup.theme.sh
@@ -13,9 +13,9 @@ function _omb_theme_sirup_rubygem {
   [[ $full ]] && echo "$full"
 }
  
-function prompt_command {
+function _omb_theme_PROMPT_COMMAND {
   # Check http://github.com/Sirupsen/dotfiles for screenshot
   PS1="$blue\W/$bold_blue$(_omb_theme_sirup_rubygem)$bold_green$(__git_ps1 " (%s)") ${normal}$ "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/slick/slick.theme.sh
+++ b/themes/slick/slick.theme.sh
@@ -54,7 +54,7 @@ modern_scm_prompt() {
         fi
 }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
 
    case $HOSTNAME in
     "clappy"* ) my_ps_host="${green}\h${normal}";
@@ -84,4 +84,4 @@ PS2="> "
 
 
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/standard/standard.theme.sh
+++ b/themes/standard/standard.theme.sh
@@ -18,8 +18,8 @@ case $TERM in
 	;;
 esac
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     PROMPT='${green}\u${normal}@${green}\h${normal}:${blue}\w${normal}${red}$(prompt_char)$(git_prompt_info)${normal}\$ '
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/tonka/tonka.theme.sh
+++ b/themes/tonka/tonka.theme.sh
@@ -17,7 +17,7 @@ __tonka_clock() {
   fi
 }
 
-prompt_setter() {
+_omb_theme_PROMPT_COMMAND() {
 
 #   Named "Tonka" because of the colour scheme
 local WHITE="\[\033[1;37m\]"
@@ -49,7 +49,7 @@ PS2="$LIGHT_BLUE-$YELLOW-$YELLOW-$NO_COLOUR "
 
 }
 
-_omb_util_add_prompt_command prompt_setter
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 THEME_SHOW_CLOCK=${THEME_SHOW_CLOCK:-"true"}
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"\[\033[1;33m\]"}

--- a/themes/tonotdo/tonotdo.theme.sh
+++ b/themes/tonotdo/tonotdo.theme.sh
@@ -6,8 +6,8 @@ SCM_THEME_PROMPT_DIRTY=" ${red}✗"
 SCM_THEME_PROMPT_CLEAN=" ${green}✓"
 SCM_GIT_SHOW_DETAILS="false"
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
   PS1="${yellow}\u${normal}${cyan}@\h${normal}${purple} ${normal}${green}\w${normal}$(scm_prompt_info)> "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/tylenol/tylenol.theme.sh
+++ b/themes/tylenol/tylenol.theme.sh
@@ -13,8 +13,8 @@ RVM_THEME_PROMPT_SUFFIX="|"
 VIRTUALENV_THEME_PROMPT_PREFIX='|'
 VIRTUALENV_THEME_PROMPT_SUFFIX='|'
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     PS1="\n${green}$(_omb_prompt_print_python_venv)${red}$(_omb_prompt_print_ruby_env) ${reset_color}\h ${orange}in ${reset_color}\w\n${yellow}$(scm_char)$(scm_prompt_info) ${yellow}→${white} "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/wanelo/wanelo.theme.sh
+++ b/themes/wanelo/wanelo.theme.sh
@@ -12,7 +12,7 @@ GIT_THEME_PROMPT_SUFFIX="${green}|"
 RVM_THEME_PROMPT_PREFIX="|"
 RVM_THEME_PROMPT_SUFFIX="|"
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     if [ $? -eq 0 ]; then
       status=❤️
     else
@@ -23,4 +23,4 @@ function prompt_command() {
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$blue"}
 
-PROMPT_COMMAND=prompt_command;
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/zitron/zitron.theme.sh
+++ b/themes/zitron/zitron.theme.sh
@@ -13,7 +13,7 @@ GIT_THEME_PROMPT_SUFFIX=""
 export LSCOLORS="Gxfxcxdxbxegedabagacad"
 export LS_COLORS="no=00:fi=00:di=01;33:ln=01;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:ex=01;32:*.tar=01;31:*.tgz=01;31:*.svgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.lzma=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.rar=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;34:*.svg=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:"
 
-function prompt_command() {
+function _omb_theme_PROMPT_COMMAND() {
     ## look-a-like
     # user:host:pwd git-branch(*)$
     # for example:
@@ -21,4 +21,4 @@ function prompt_command() {
     PS1="${no_color}\u:$(hostname)${normal}:${bold_yellow}\W/${normal} $(git_prompt_info)${reset_color}$ "
 }
 
-_omb_util_add_prompt_command prompt_command
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/zork/zork.theme.sh
+++ b/themes/zork/zork.theme.sh
@@ -66,7 +66,7 @@ my_ve(){
     echo "";
     }
 
-prompt() {
+_omb_theme_PROMPT_COMMAND() {
 
     my_ps_host="${green}\h${normal}";
     # yes, these are the the same for now ...
@@ -95,4 +95,4 @@ PS2="└─▪ "
 
 
 
-_omb_util_add_prompt_command prompt
+_omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -63,7 +63,7 @@ _omb_install_run() {
     printf '%s\n' "$BOLD$GREEN[dryrun]$NORMAL $BOLD$*$NORMAL" >&5
   else
     printf '%s\n' "$BOLD\$ $*$NORMAL" >&5
-    "$@"
+    command "$@"
   fi
 }
 
@@ -124,19 +124,19 @@ _omb_install_main() {
   umask g-w,o-w
 
   printf "${BLUE}Cloning Oh My Bash...${NORMAL}\n"
-  hash git >/dev/null 2>&1 || {
+  type -P git &>/dev/null || {
     echo "Error: git is not installed"
     return 1
   }
   # The Windows (MSYS) Git is not compatible with normal use on cygwin
   if [[ $OSTYPE = cygwin ]]; then
-    if git --version | grep msysgit > /dev/null; then
+    if command git --version | command grep msysgit > /dev/null; then
       echo "Error: Windows/MSYS Git is not supported on Cygwin"
       echo "Error: Make sure the Cygwin git package is installed and is first on the path"
       return 1
     fi
   fi
-  _omb_install_run env git clone --depth=1 https://github.com/ohmybash/oh-my-bash.git "$OSH" || {
+  _omb_install_run git clone --depth=1 https://github.com/ohmybash/oh-my-bash.git "$OSH" || {
     printf "Error: git clone of oh-my-bash repo failed\n"
     return 1
   }

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Note: this file is intentionally written in POSIX sh so that oh-my-bash can
+# be uninstalled without bash.
+
 _omb_uninstall_contains_omb() {
-  grep -qE '(source|\.)[[:space:]]+.*[/[:space:]]oh-my-bash\.sh' "$1" 2>/dev/null
+  command grep -qE '(source|\.)[[:space:]]+.*[/[:space:]]oh-my-bash\.sh' "$1" 2>/dev/null
 }
 
 # Find the latest bashrc that do not source oh-my-bash.sh
@@ -36,7 +39,7 @@ unset _omb_uninstall_confirmation
 
 if [ -d ~/.oh-my-bash ]; then
   printf '%s\n' "Removing ~/.oh-my-bash"
-  rm -rf ~/.oh-my-bash
+  command rm -rf ~/.oh-my-bash
 fi
 
 _omb_uninstall_bashrc_original=
@@ -56,16 +59,16 @@ _omb_uninstall_bashrc_uninstalled=
 if [ -e ~/.bashrc ] || [ -h ~/.bashrc ]; then
   _omb_uninstall_bashrc_uninstalled=".bashrc.omb-uninstalled-$(date +%Y%m%d%H%M%S)";
   printf '%s\n' "Found ~/.bashrc -- Renaming to ~/${_omb_uninstall_bashrc_uninstalled}";
-  mv ~/.bashrc ~/"${_omb_uninstall_bashrc_uninstalled}";
+  command mv ~/.bashrc ~/"${_omb_uninstall_bashrc_uninstalled}";
 fi
 
 if [ -n "$_omb_uninstall_bashrc_original" ]; then
   printf '%s\n' "Found $_omb_uninstall_bashrc_original -- Restoring to ~/.bashrc";
-  mv "$_omb_uninstall_bashrc_original" ~/.bashrc;
+  command mv "$_omb_uninstall_bashrc_original" ~/.bashrc;
   printf '%s\n' "Your original bash config was restored. Please restart your session."
 else
-  sed '/oh-my-bash\.sh/s/^/: #/' ~/"${_omb_uninstall_bashrc_uninstalled:-.bashrc}" >| ~/.bashrc.omb-temp && \
-    mv ~/.bashrc.omb-temp ~/.bashrc
+  command sed '/oh-my-bash\.sh/s/^/: #/' ~/"${_omb_uninstall_bashrc_uninstalled:-.bashrc}" >| ~/.bashrc.omb-temp && \
+    command mv ~/.bashrc.omb-temp ~/.bashrc
 fi
 
 unset _omb_uninstall_bashrc_original
@@ -73,5 +76,9 @@ unset _omb_uninstall_bashrc_uninstalled
 
 echo "Thanks for trying out Oh My Bash. It has been uninstalled."
 case $- in
-*i*) exec bash; source ~/.bashrc ;;
+*i*)
+  if [ -n "${BASH_VERSION-}" ]; then
+    declare -f _omb_util_unload >/dev/null 2>&1 && _omb_util_unload
+    source ~/.bashrc
+  fi ;;
 esac

--- a/tools/upgrade.sh
+++ b/tools/upgrade.sh
@@ -1,29 +1,35 @@
 #!/usr/bin/env bash
 
-# Use colors, but only if connected to a terminal, and that terminal
-# supports them.
-if which tput >/dev/null 2>&1; then
-    ncolors=$(tput colors)
-fi
-if [ -t 1 ] && [ -n "$ncolors" ] && [ "$ncolors" -ge 8 ]; then
-  RED=$(tput setaf 1)
-  GREEN=$(tput setaf 2)
-  YELLOW=$(tput setaf 3)
-  BLUE=$(tput setaf 4)
-  BOLD=$(tput bold)
-  NORMAL=$(tput sgr0)
-else
-  RED=""
-  GREEN=""
-  YELLOW=""
-  BLUE=""
-  BOLD=""
-  NORMAL=""
-fi
+function _omb_upgrade {
+  # Use colors, but only if connected to a terminal, and that terminal
+  # supports them.
+  if type -P tput &>/dev/null; then
+    local ncolors=$(tput colors)
+  fi
 
-printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Bash"
+  if [[ -t 1 && $ncolors && $ncolors -ge 8 ]]; then
+    local RED=$(tput setaf 1)
+    local GREEN=$(tput setaf 2)
+    local YELLOW=$(tput setaf 3)
+    local BLUE=$(tput setaf 4)
+    local BOLD=$(tput bold)
+    local NORMAL=$(tput sgr0)
+  else
+    local RED=""
+    local GREEN=""
+    local YELLOW=""
+    local BLUE=""
+    local BOLD=""
+    local NORMAL=""
+  fi
 
-if git -C "$OSH" pull --rebase --stat origin master; then
+  printf "${BLUE}%s${NORMAL}\n" "Updating Oh My Bash"
+
+  if ! command git -C "$OSH" pull --rebase --stat origin master; then
+    printf "${RED}%s${NORMAL}\n" 'There was an error updating. Try again later?'
+    return 1
+  fi
+
   printf '%s' "$GREEN"
   printf '%s\n' '         __                          __               __  '
   printf '%s\n' '  ____  / /_     ____ ___  __  __   / /_  ____ ______/ /_ '
@@ -33,7 +39,9 @@ if git -C "$OSH" pull --rebase --stat origin master; then
   printf '%s\n' '                        /____/                            '
   printf "${BLUE}%s\n" "Hooray! Oh My Bash has been updated and/or is at the current version."
   printf "${BLUE}${BOLD}%s${NORMAL}\n" "To keep up on the latest news and updates, follow us on GitHub: https://github.com/ohmybash/oh-my-bash"
-  exec bash; source ~/.bashrc
-else
-  printf "${RED}%s${NORMAL}\n" 'There was an error updating. Try again later?'
-fi
+  if [[ $- == *i* ]]; then
+    declare -f _omb_util_unload &>/dev/null && _omb_util_unload
+    source ~/.bashrc
+  fi
+}
+_omb_upgrade


### PR DESCRIPTION
This PR allows installing/upgrading/uninstalling OMB within the interactive shell process. This was mentioned in https://github.com/ohmybash/oh-my-bash/commit/028d2537392a5e1ec8166600105840e107eb65c9#commitcomment-62954551 and also addressed in [#206](https://github.com/ohmybash/oh-my-bash/pull/206/files#diff-4b98dbe69610bd8f3e7440e55255e2fd22da4659b509cefbe976c3e03d6458e0L37-R38) (incompletely/incorrectly).

- To avoid multiple PROMPT_COMMAND handlers after updating and loading OMB again, the name of `PROMPT_COMMAND` handlers are made consistent over different themes, and its registration is refactored.
- Protecting the executions of `grep`, `sed`, `mkdir`, etc. inside installing/upgrading scripts from aliases by prefixing them by `command`.
- Namespacing shell functions and shell variables used in installing/upgrading scripts to avoid conflicts.
- Other various fixes.