### PR TITLE
Fixes user defined aliases being overridden by OMB 

### DIFF
--- a/lib/bourne-shell.sh
+++ b/lib/bourne-shell.sh
@@ -60,13 +60,25 @@ esac
 # enable color support of ls and also add handy aliases
 if [ -x /usr/bin/dircolors ]; then
   test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
-  alias ls='ls --color=auto'
-  #alias dir='dir --color=auto'
-  #alias vdir='vdir --color=auto'
+  if ! alias ls >/dev/null 2>&1; then
+    alias ls='ls --color=auto'
+  fi
+  #if ! alias dir >/dev/null 2>&1; then
+  #  alias dir='dir --color=auto'
+  #fi
+  #if ! alias vdir; then
+  #  alias vdir='vdir --color=auto'
+  #fi
 
-  alias grep='grep --color=auto'
-  alias fgrep='fgrep --color=auto'
-  alias egrep='egrep --color=auto'
+  if ! alias grep >/dev/null 2>&1; then
+    alias grep='grep --color=auto'
+  fi
+  if ! alias fgrep >/dev/null 2>&1; then
+    alias fgrep='fgrep --color=auto'
+  fi
+  if ! alias egrep >/dev/null 2>&1; then
+    alias egrep='egrep --color=auto'
+  fi
 fi
 
 # colored GCC warnings and errors

--- a/lib/bourne-shell.sh
+++ b/lib/bourne-shell.sh
@@ -60,38 +60,25 @@ esac
 # enable color support of ls and also add handy aliases
 if [ -x /usr/bin/dircolors ]; then
   test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
-  if ! alias ls >/dev/null 2>&1; then
-    alias ls='ls --color=auto'
-  fi
-  #if ! alias dir >/dev/null 2>&1; then
-  #  alias dir='dir --color=auto'
-  #fi
-  #if ! alias vdir; then
-  #  alias vdir='vdir --color=auto'
-  #fi
-
-  if ! alias grep >/dev/null 2>&1; then
-    alias grep='grep --color=auto'
-  fi
-  if ! alias fgrep >/dev/null 2>&1; then
-    alias fgrep='fgrep --color=auto'
-  fi
-  if ! alias egrep >/dev/null 2>&1; then
-    alias egrep='egrep --color=auto'
-  fi
+  _omb_util_alias ls='ls --color=auto'
+  #_omb_util_alias ls='dir --color=auto'
+  #_omb_util_alias vdir='vdir --color=auto'
+  _omb_util_alias grep='grep --color=auto'
+  _omb_util_alias fgrep='fgrep --color=auto'
+  _omb_util_alias egrep='egrep --color=auto'
 fi
 
 # colored GCC warnings and errors
 #export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
 
 # some more ls aliases
-alias ll='ls -alF'
-alias la='ls -A'
-alias l='ls -CF'
+_omb_util_alias ll='ls -alF'
+_omb_util_alias la='ls -A'
+_omb_util_alias l='ls -CF'
 
 # Add an "alert" alias for long running commands.  Use like so:
 #   sleep 10; alert
-alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+_omb_util_alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
 
 # Alias definitions.
 # You may want to put all your additions into a separate file like

--- a/lib/bourne-shell.sh
+++ b/lib/bourne-shell.sh
@@ -63,18 +63,14 @@ if [ -x /usr/bin/dircolors ]; then
   _omb_util_alias ls='ls --color=auto'
   #_omb_util_alias ls='dir --color=auto'
   #_omb_util_alias vdir='vdir --color=auto'
-  _omb_util_alias grep='grep --color=auto'
-  _omb_util_alias fgrep='fgrep --color=auto'
-  _omb_util_alias egrep='egrep --color=auto'
+
+  # Note: aliases "grep", "fgrep", and "egrep" are merged in lib/grep.sh
 fi
 
 # colored GCC warnings and errors
 #export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
 
-# some more ls aliases
-_omb_util_alias ll='ls -alF'
-_omb_util_alias la='ls -A'
-_omb_util_alias l='ls -CF'
+# ls aliases are moved to "lib/directories.sh"
 
 # Add an "alert" alias for long running commands.  Use like so:
 #   sleep 10; alert

--- a/lib/directories.sh
+++ b/lib/directories.sh
@@ -24,7 +24,12 @@ _omb_util_alias rd='rmdir'
 _omb_util_alias d='dirs -v | head -10'
 
 # List directory contents
-_omb_util_alias lsa='ls -lah'
-_omb_util_alias l='ls -lah'
+_omb_util_alias lsa='ls -lha'
+_omb_util_alias l='ls -lha'
 _omb_util_alias ll='ls -lh'
-_omb_util_alias la='ls -lAh'
+_omb_util_alias la='ls -lhA'
+
+# From bourne-shell.sh (unused)
+#_omb_util_alias l='ls -CF'
+#_omb_util_alias ll='ls -laF'
+#_omb_util_alias la='ls -A'

--- a/lib/directories.sh
+++ b/lib/directories.sh
@@ -1,30 +1,30 @@
 #! bash oh-my-bash.module
 # Common directories functions
-alias cd..='cd ../'                         # Go back 1 directory level (for fast typers)
-alias ..='cd ../'                           # Go back 1 directory level
-alias ...='cd ../../'                       # Go back 2 directory levels
-alias .3='cd ../../../'                     # Go back 3 directory levels
-alias .4='cd ../../../../'                  # Go back 4 directory levels
-alias .5='cd ../../../../../'               # Go back 5 directory levels
-alias .6='cd ../../../../../../'            # Go back 6 directory levels
+_omb_util_alias cd..='cd ../'                         # Go back 1 directory level (for fast typers)
+_omb_util_alias ..='cd ../'                           # Go back 1 directory level
+_omb_util_alias ...='cd ../../'                       # Go back 2 directory levels
+_omb_util_alias .3='cd ../../../'                     # Go back 3 directory levels
+_omb_util_alias .4='cd ../../../../'                  # Go back 4 directory levels
+_omb_util_alias .5='cd ../../../../../'               # Go back 5 directory levels
+_omb_util_alias .6='cd ../../../../../../'            # Go back 6 directory levels
 
-alias -- -='cd -'
-alias 1='cd -'
-alias 2='cd -2'
-alias 3='cd -3'
-alias 4='cd -4'
-alias 5='cd -5'
-alias 6='cd -6'
-alias 7='cd -7'
-alias 8='cd -8'
-alias 9='cd -9'
+_omb_util_alias -='cd -'
+_omb_util_alias 1='cd -'
+_omb_util_alias 2='cd -2'
+_omb_util_alias 3='cd -3'
+_omb_util_alias 4='cd -4'
+_omb_util_alias 5='cd -5'
+_omb_util_alias 6='cd -6'
+_omb_util_alias 7='cd -7'
+_omb_util_alias 8='cd -8'
+_omb_util_alias 9='cd -9'
 
-alias md='mkdir -p'
-alias rd='rmdir'
-alias d='dirs -v | head -10'
+_omb_util_alias md='mkdir -p'
+_omb_util_alias rd='rmdir'
+_omb_util_alias d='dirs -v | head -10'
 
 # List directory contents
-alias lsa='ls -lah'
-alias l='ls -lah'
-alias ll='ls -lh'
-alias la='ls -lAh'
+_omb_util_alias lsa='ls -lah'
+_omb_util_alias l='ls -lah'
+_omb_util_alias ll='ls -lh'
+_omb_util_alias la='ls -lAh'

--- a/lib/grep.sh
+++ b/lib/grep.sh
@@ -24,6 +24,8 @@ fi
 # export grep settings
 if ((${#_omb_grep_options[@]} > 0)); then
   _omb_util_alias grep="grep ${_omb_grep_options[*]}"
+  _omb_util_alias grep="fgrep ${_omb_grep_options[*]}"
+  _omb_util_alias grep="egrep ${_omb_grep_options[*]}"
 fi
 
 # clean up

--- a/lib/grep.sh
+++ b/lib/grep.sh
@@ -23,7 +23,7 @@ fi
 
 # export grep settings
 if ((${#_omb_grep_options[@]} > 0)); then
-  alias grep="grep ${_omb_grep_options[*]}"
+  _omb_util_alias grep="grep ${_omb_grep_options[*]}"
 fi
 
 # clean up

--- a/lib/misc.sh
+++ b/lib/misc.sh
@@ -7,14 +7,14 @@ env_default PAGER 'less'
 env_default LESS '-R'
 
 ## super user alias
-alias _='sudo'
-alias please='sudo'
+_omb_util_alias _='sudo'
+_omb_util_alias please='sudo'
 
 ## more intelligent acking for ubuntu users
 if which ack-grep &> /dev/null; then
-  alias afind='ack-grep -il'
+  _omb_util_alias afind='ack-grep -il'
 else
-  alias afind='ack -il'
+  _omb_util_alias afind='ack -il'
 fi
 
 # only define LC_CTYPE if undefined

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -388,3 +388,15 @@ _omb_util_glob_expand() {
   [[ :$shopt: == *:failglob:* ]] && shopt -s failglob
   return 0
 }
+
+_omb_util_alias() {
+  case ${OMB_DEFAULT_ALIASES:-enable} in
+  (disable) return 0 ;;
+  (check) alias -- "${1%%=*}" &>/dev/null && return 0 ;;
+  (enable) ;;
+  (*)
+    _omb_log_error "invalid value: OMB_DEFAULT_ALIASES='${OMB_DEFAULT_ALIASES-}' (expect: enable|disable|check)" >&2
+    return 2
+  esac
+  alias -- "$1"
+}

--- a/templates/bashrc.osh-template
+++ b/templates/bashrc.osh-template
@@ -46,6 +46,10 @@ OSH_THEME="font"
 # The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
 # HIST_STAMPS="mm/dd/yyyy"
 
+# Uncomment the following line if you do not want OMB to overwrite the existing
+# aliases by the default OMB aliases defined in lib/*.sh
+# OMB_DEFAULT_ALIASES="check"
+
 # Would you like to use another custom folder than $OSH/custom?
 # OSH_CUSTOM=/path/to/new-custom-folder
 


### PR DESCRIPTION
Fixes #304.

Currenty, oh-my-bash currently overrides any aliases that has been set for `ls`, `grep`, `egrep`, and `fgrep`, if the file `/usr/bin/dircolors` exists.
This means if a user specifies any aliases before OMB is sourced, they will be overwritten in a manner which is non transparent to the user (It is not stated anywhere, and the user cannot explicitly disabled it).

The goal of this PR is to not overwrite the aliases if they already exist, preferring the pre-defined aliases instead.
Alternatively, a means of disabling the new OMB aliases could be introduced through an environment variable, to allow the user to not have them set.

Currently, it wraps each alias call in an `if` statement, to check if they exist prior to applying them.
But, as per suggestions from akinomyoga, a function shall be introduced to streamline this process, in addition to refactors to all the other aliases which are defined by OMB that are *not* in the aliases folder or the plugins folder.