### PR TITLE
Update repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export OSH="$HOME/.dotfiles/oh-my-bash"; bash -c "$(curl -fsSL https://raw.githu
 ##### 1. Clone the repository:
 
 ```shell
-git clone git://github.com/ohmybash/oh-my-bash.git ~/.oh-my-bash
+git clone https://github.com/ohmybash/oh-my-bash.git ~/.oh-my-bash
 ```
 
 ##### 2. *Optionally*, backup your existing `~/.bashrc` file:


### PR DESCRIPTION
This clone line fails with:
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.