### PR TITLE
themes/sirup: Show VirtualEnv

### DIFF
--- a/themes/sirup/sirup.theme.sh
+++ b/themes/sirup/sirup.theme.sh
@@ -1,8 +1,8 @@
 #! bash oh-my-bash.module
 # For unstaged(*) and staged(+) values next to branch name in __git_ps1
 GIT_PS1_SHOWDIRTYSTATE="enabled"
-OMB_PROMPT_VIRTUALENV_FORMAT='[%s] '
-OMB_PROMPT_CONDAENV_FORMAT='[%s] '
+OMB_PROMPT_VIRTUALENV_FORMAT=' [%s]'
+OMB_PROMPT_CONDAENV_FORMAT=' [%s]'
 OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
 
 function _omb_theme_sirup_rubygem {
@@ -20,7 +20,7 @@ function _omb_theme_PROMPT_COMMAND {
   # Check http://github.com/Sirupsen/dotfiles for screenshot
   local python_venv
   _omb_prompt_get_python_venv
-  PS1="$_omb_prompt_purple$python_venv$_omb_prompt_navy\W/$_omb_prompt_bold_navy$(_omb_theme_sirup_rubygem)$_omb_prompt_bold_green$(__git_ps1 " (%s)") ${_omb_prompt_normal}$ "
+  PS1="$_omb_prompt_navy\W/$_omb_prompt_bold_navy$(_omb_theme_sirup_rubygem)$_omb_prompt_bold_purple$python_venv$_omb_prompt_bold_green$(__git_ps1 " (%s)") ${_omb_prompt_normal}$ "
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/sirup/sirup.theme.sh
+++ b/themes/sirup/sirup.theme.sh
@@ -3,6 +3,7 @@
 GIT_PS1_SHOWDIRTYSTATE="enabled"
 OMB_PROMPT_VIRTUALENV_FORMAT='[%s] '
 OMB_PROMPT_CONDAENV_FORMAT='[%s] '
+OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
 
 function _omb_theme_sirup_rubygem {
   local gemset=$(command awk -F'@' '{print $2}' <<< "$GEM_HOME")

--- a/themes/sirup/sirup.theme.sh
+++ b/themes/sirup/sirup.theme.sh
@@ -1,16 +1,8 @@
 #! bash oh-my-bash.module
 # For unstaged(*) and staged(+) values next to branch name in __git_ps1
 GIT_PS1_SHOWDIRTYSTATE="enabled"
-
-function omb_theme_syrup_python_venv {
-  local python_venv=""
-
-  if [[ -n "${VIRTUAL_ENV}" ]]; then
-    python_venv=$(basename "${VIRTUAL_ENV}")
-  fi
-
-  [[ -n "${python_venv}" ]] && echo "[${python_venv}] "
-}
+OMB_PROMPT_VIRTUALENV_FORMAT='[%s] '
+OMB_PROMPT_CONDAENV_FORMAT='[%s] '
 
 function _omb_theme_sirup_rubygem {
   local gemset=$(command awk -F'@' '{print $2}' <<< "$GEM_HOME")
@@ -25,7 +17,9 @@ function _omb_theme_sirup_rubygem {
  
 function _omb_theme_PROMPT_COMMAND {
   # Check http://github.com/Sirupsen/dotfiles for screenshot
-  PS1="$_omb_prompt_purple$(omb_theme_syrup_python_venv)$_omb_prompt_navy\W/$_omb_prompt_bold_navy$(_omb_theme_sirup_rubygem)$_omb_prompt_bold_green$(__git_ps1 " (%s)") ${_omb_prompt_normal}$ "
+  local python_venv
+  _omb_prompt_get_python_venv
+  PS1="$_omb_prompt_purple$python_venv$_omb_prompt_navy\W/$_omb_prompt_bold_navy$(_omb_theme_sirup_rubygem)$_omb_prompt_bold_green$(__git_ps1 " (%s)") ${_omb_prompt_normal}$ "
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/sirup/sirup.theme.sh
+++ b/themes/sirup/sirup.theme.sh
@@ -2,6 +2,16 @@
 # For unstaged(*) and staged(+) values next to branch name in __git_ps1
 GIT_PS1_SHOWDIRTYSTATE="enabled"
 
+function omb_theme_syrup_python_venv {
+  local python_venv=""
+
+  if [[ -n "${VIRTUAL_ENV}" ]]; then
+    python_venv=$(basename "${VIRTUAL_ENV}")
+  fi
+
+  [[ -n "${python_venv}" ]] && echo "[${python_venv}] "
+}
+
 function _omb_theme_sirup_rubygem {
   local gemset=$(command awk -F'@' '{print $2}' <<< "$GEM_HOME")
   [[ $gemset ]] && gemset="@$gemset"
@@ -15,7 +25,7 @@ function _omb_theme_sirup_rubygem {
  
 function _omb_theme_PROMPT_COMMAND {
   # Check http://github.com/Sirupsen/dotfiles for screenshot
-  PS1="$_omb_prompt_navy\W/$_omb_prompt_bold_navy$(_omb_theme_sirup_rubygem)$_omb_prompt_bold_green$(__git_ps1 " (%s)") ${_omb_prompt_normal}$ "
+  PS1="$_omb_prompt_purple$(omb_theme_syrup_python_venv)$_omb_prompt_navy\W/$_omb_prompt_bold_navy$(_omb_theme_sirup_rubygem)$_omb_prompt_bold_green$(__git_ps1 " (%s)") ${_omb_prompt_normal}$ "
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND


### PR DESCRIPTION
Added the ability to show the current Virtual Env when using Python Virtual Env. 
If there's not vitual env, the theme works normal.