### PR TITLE
Fixed unbound variable error

### DIFF
--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -233,9 +233,10 @@ function git_status_summary {
 
 function git_prompt_vars {
   local details=''
+  local git_status_flags=''
   SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
   if [[ "$(git config --get bash-it.hide-status)" != "1" ]]; then
-    [[ "${SCM_GIT_IGNORE_UNTRACKED}" = "true" ]] && local git_status_flags='-uno'
+    [[ "${SCM_GIT_IGNORE_UNTRACKED}" = "true" ]] && git_status_flags='-uno'
     local status_lines=$((git status --porcelain ${git_status_flags} -b 2> /dev/null ||
                           git status --porcelain ${git_status_flags}    2> /dev/null) | git_status_summary)
     local status=$(awk 'NR==1' <<< "$status_lines")


### PR DESCRIPTION
git_status_flags variable wasn't in the function git_prompt_vars, so if `set -u` was set in bashrc, it would give unbound variable error constantly.