### PR TITLE
themes/sexy: display active conda environment's name in bash prompt

### DIFF
--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -75,7 +75,9 @@ CHRUBY_THEME_PROMPT_SUFFIX='|'
 # # new
 # OMB_PROMPT_VIRTUALENV_FORMAT=' |%s|'
 # OMB_PROMPT_CONDAENV_FORMAT=' |%s|'
+# OMB_PROMPT_CONDAENV_USE_BASENAME=true
 # OMB_PROMPT_PYTHON_VERSION_FORMAT=' |%s|'
+# OMB_PROMPT_SHOW_PYTHON_VENV=true
 
 # deprecate
 VIRTUALENV_THEME_PROMPT_PREFIX=' |'
@@ -456,8 +458,13 @@ function _omb_prompt_get_virtualenv {
 
 function _omb_prompt_get_condaenv {
   condaenv=
-  [[ ${CONDA_DEFAULT_ENV-} ]] || return 1
-  _omb_prompt_format condaenv "$CONDA_DEFAULT_ENV" OMB_PROMPT_CONDAENV:CONDAENV_THEME_PROMPT
+  [[ ${CONDA_DEFAULT_ENV-} && ${CONDA_SHLVL-} != 0 ]] || return 1
+
+  local condaenv=$CONDA_DEFAULT_ENV
+  if [[ ${OMB_PROMPT_CONDAENV_USE_BASENAME-} == true ]]; then
+    condaenv=$(basename "$condaenv")
+  fi
+  _omb_prompt_format condaenv "$condaenv" OMB_PROMPT_CONDAENV:CONDAENV_THEME_PROMPT
 }
 
 function _omb_prompt_get_python_version {

--- a/lib/omb-prompt-colors.sh
+++ b/lib/omb-prompt-colors.sh
@@ -90,16 +90,20 @@ function _omb_prompt_color_initialize {
 
   local -a normal_colors=(black brown green olive navy purple teal silver)
   local -a bright_colors=(gray red lime yellow blue magenta cyan white)
+
+  local bright_fg_prefix=9 bright_bg_prefix=10
+  ((_omb_term_colors >= 16)) || bright_fg_prefix=3 bright_bg_prefix=4
+
   local index
   for ((index = 0; index < 8; index++)); do
     printf -v "_omb_prompt_${normal_colors[index]}" %s '\[\e[0;3'"$index"'m\]'
     printf -v "_omb_prompt_bold_${normal_colors[index]}" %s '\[\e[3'"$index"';1m\]'
     printf -v "_omb_prompt_underline_${normal_colors[index]}" %s '\[\e[3'"$index"';4m\]'
     printf -v "_omb_prompt_background_${normal_colors[index]}" %s '\[\e[4'"$index"'m\]'
-    printf -v "_omb_prompt_${bright_colors[index]}" %s '\[\e[0;9'"$index"'m\]'
-    printf -v "_omb_prompt_bold_${bright_colors[index]}" %s '\[\e[9'"$index"';1m\]'
-    printf -v "_omb_prompt_underline_${bright_colors[index]}" %s '\[\e[9'"$index"';4m\]'
-    printf -v "_omb_prompt_background_${bright_colors[index]}" %s '\[\e[10'"$index"'m\]'
+    printf -v "_omb_prompt_${bright_colors[index]}" %s '\[\e[0;'"$bright_fg_prefix$index"'m\]'
+    printf -v "_omb_prompt_bold_${bright_colors[index]}" %s '\[\e['"$bright_fg_prefix$index"';1m\]'
+    printf -v "_omb_prompt_underline_${bright_colors[index]}" %s '\[\e['"$bright_fg_prefix$index"';4m\]'
+    printf -v "_omb_prompt_background_${bright_colors[index]}" %s '\[\e['"$bright_bg_prefix$index"'m\]'
   done
 }
 _omb_prompt_color_initialize

--- a/themes/axin/axin.theme.sh
+++ b/themes/axin/axin.theme.sh
@@ -3,38 +3,26 @@
 # Axin Bash Prompt, inspired by theme "Sexy" and "Bobby"
 # thanks to them
 
-if [[ $COLORTERM = gnome-* && $TERM = xterm ]]  && infocmp gnome-256color >/dev/null 2>&1; then export TERM=gnome-256color
-elif [[ $TERM != dumb ]] && infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
+if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color &>/dev/null; then
+  export TERM=gnome-256color
+elif [[ $TERM != dumb ]] && infocmp xterm-256color &>/dev/null; then
+  export TERM=xterm-256color
 fi
 
-if tput setaf 1 &> /dev/null; then
-    if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
-      MAGENTA=$(tput setaf 9)
-      ORANGE=$(tput setaf 172)
-      GREEN=$(tput setaf 190)
-      PURPLE=$(tput setaf 141)
-      WHITE=$(tput setaf 0)
-    else
-      MAGENTA=$(tput setaf 5)
-      ORANGE=$(tput setaf 4)
-      GREEN=$(tput setaf 2)
-      PURPLE=$(tput setaf 1)
-      WHITE=$(tput setaf 7)
-    fi
-    BOLD=$(tput bold)
-    RESET=$(tput sgr0)
-else
-    MAGENTA="\033[1;31m"
-    ORANGE="\033[1;33m"
-    GREEN="\033[1;32m"
-    PURPLE="\033[1;35m"
-    WHITE="\033[1;37m"
-    BOLD=""
-    RESET="\033[m"
+MAGENTA=$_omb_prompt_bold_red
+WHITE=$_omb_prompt_bold_silver
+ORANGE=$_omb_prompt_bold_olive
+GREEN=$_omb_prompt_bold_green
+PURPLE=$_omb_prompt_bold_purple
+RESET=$_omb_prompt_normal
+if ((_omb_term_colors >= 256)); then
+  ORANGE=$_omb_prompt_bold'\['$(tput setaf 172)'\]'
+  GREEN=$_omb_prompt_bold'\['$(tput setaf 190)'\]'
+  PURPLE=$_omb_prompt_bold'\['$(tput setaf 141)'\]'
 fi
 
 function _omb_theme_PROMPT_COMMAND() {
-  PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]@ \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\[$SCM_THEME_PROMPT_PREFIX\]$(clock_prompt) \[$PURPLE\]\$(scm_prompt_info) \n\$ \[$RESET\]"
+  PS1="${MAGENTA}\u ${WHITE}@ ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}$SCM_THEME_PROMPT_PREFIX$(clock_prompt) ${PURPLE}\$(scm_prompt_info) \n\$ ${RESET}"
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"${_omb_prompt_white}"}

--- a/themes/axin/axin.theme.sh
+++ b/themes/axin/axin.theme.sh
@@ -21,8 +21,15 @@ if ((_omb_term_colors >= 256)); then
   PURPLE=$_omb_prompt_bold'\['$(tput setaf 141)'\]'
 fi
 
+OMB_PROMPT_VIRTUALENV_FORMAT=$WHITE'<%s> '
+OMB_PROMPT_CONDAENV_FORMAT=$WHITE'<%s> '
+OMB_PROMPT_CONDAENV_USE_BASENAME=true
+OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
+
 function _omb_theme_PROMPT_COMMAND() {
-  PS1="${MAGENTA}\u ${WHITE}@ ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}$SCM_THEME_PROMPT_PREFIX$(clock_prompt) ${PURPLE}\$(scm_prompt_info) \n\$ ${RESET}"
+  local python_venv
+  _omb_prompt_get_python_venv
+  PS1="$python_venv${MAGENTA}\u ${WHITE}@ ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}$SCM_THEME_PROMPT_PREFIX$(clock_prompt) ${PURPLE}\$(scm_prompt_info) \n\$ ${RESET}"
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"${_omb_prompt_white}"}

--- a/themes/sexy/sexy.theme.sh
+++ b/themes/sexy/sexy.theme.sh
@@ -3,42 +3,28 @@
 # Screenshot: http://cloud.gf3.ca/M5rG
 # A big thanks to \amethyst on Freenode
 
-OMB_PROMPT_VIRTUALENV_FORMAT=$_omb_prompt_bold_silver'<%s> '
-OMB_PROMPT_CONDAENV_FORMAT=$_omb_prompt_bold_silver'<%s> '
-OMB_PROMPT_CONDAENV_USE_BASENAME=true
-OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
-
 if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color &>/dev/null; then
   export TERM=gnome-256color
 elif [[ $TERM != dumb ]] && infocmp xterm-256color &>/dev/null; then
   export TERM=xterm-256color
 fi
 
-if tput setaf 1 &> /dev/null; then
-  if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
-    MAGENTA=$(tput setaf 9)
-    ORANGE=$(tput setaf 172)
-    GREEN=$(tput setaf 190)
-    PURPLE=$(tput setaf 141)
-    WHITE=$(tput setaf 0)
-  else
-    MAGENTA=$(tput setaf 5)
-    ORANGE=$(tput setaf 4)
-    GREEN=$(tput setaf 2)
-    PURPLE=$(tput setaf 1)
-    WHITE=$(tput setaf 7)
-  fi
-  BOLD=$(tput bold)
-  RESET=$(tput sgr0)
-else
-  MAGENTA="\033[1;31m"
-  ORANGE="\033[1;33m"
-  GREEN="\033[1;32m"
-  PURPLE="\033[1;35m"
-  WHITE="\033[1;37m"
-  BOLD=""
-  RESET="\033[m"
+MAGENTA=$_omb_prompt_bold_red
+WHITE=$_omb_prompt_bold_silver
+ORANGE=$_omb_prompt_bold_olive
+GREEN=$_omb_prompt_bold_green
+PURPLE=$_omb_prompt_bold_purple
+RESET=$_omb_prompt_normal
+if ((_omb_term_colors >= 256)); then
+  ORANGE=$_omb_prompt_bold'\['$(tput setaf 172)'\]'
+  GREEN=$_omb_prompt_bold'\['$(tput setaf 190)'\]'
+  PURPLE=$_omb_prompt_bold'\['$(tput setaf 141)'\]'
 fi
+
+OMB_PROMPT_VIRTUALENV_FORMAT=$WHITE'<%s> '
+OMB_PROMPT_CONDAENV_FORMAT=$WHITE'<%s> '
+OMB_PROMPT_CONDAENV_USE_BASENAME=true
+OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
 
 function parse_git_dirty {
   [[ $(git status 2> /dev/null | tail -n1 | cut -c 1-17) != "nothing to commit" ]] && echo "*"
@@ -50,7 +36,7 @@ function parse_git_branch {
 function _omb_theme_PROMPT_COMMAND() {
   local python_venv
   _omb_prompt_get_python_venv
-  PS1="$python_venv\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")\[$PURPLE\]\$(parse_git_branch)\[$WHITE\]\n\$ \[$RESET\]"
+  PS1="$python_venv${MAGENTA}\u ${WHITE}at ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")${PURPLE}\$(parse_git_branch)${WHITE}\n\$ ${RESET}"
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/sexy/sexy.theme.sh
+++ b/themes/sexy/sexy.theme.sh
@@ -3,6 +3,11 @@
 # Screenshot: http://cloud.gf3.ca/M5rG
 # A big thanks to \amethyst on Freenode
 
+OMB_PROMPT_VIRTUALENV_FORMAT=$_omb_prompt_bold_silver'<%s> '
+OMB_PROMPT_CONDAENV_FORMAT=$_omb_prompt_bold_silver'<%s> '
+OMB_PROMPT_CONDAENV_USE_BASENAME=true
+OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
+
 if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color &>/dev/null; then
   export TERM=gnome-256color
 elif [[ $TERM != dumb ]] && infocmp xterm-256color &>/dev/null; then
@@ -43,10 +48,9 @@ function parse_git_branch {
 }
 
 function _omb_theme_PROMPT_COMMAND() {
-  PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")\[$PURPLE\]\$(parse_git_branch)\[$WHITE\]\n\$ \[$RESET\]"
-  if [[ $CONDA_SHLVL == 1 ]]; then
-    PS1="\[${BOLD}${WHITE}\]<$(basename $CONDA_DEFAULT_ENV)> $PS1"
-  fi
+  local python_venv
+  _omb_prompt_get_python_venv
+  PS1="$python_venv\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")\[$PURPLE\]\$(parse_git_branch)\[$WHITE\]\n\$ \[$RESET\]"
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/sexy/sexy.theme.sh
+++ b/themes/sexy/sexy.theme.sh
@@ -3,34 +3,36 @@
 # Screenshot: http://cloud.gf3.ca/M5rG
 # A big thanks to \amethyst on Freenode
 
-if [[ $COLORTERM = gnome-* && $TERM = xterm ]]  && infocmp gnome-256color >/dev/null 2>&1; then export TERM=gnome-256color
-elif [[ $TERM != dumb ]] && infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
+if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color &>/dev/null; then
+  export TERM=gnome-256color
+elif [[ $TERM != dumb ]] && infocmp xterm-256color &>/dev/null; then
+  export TERM=xterm-256color
 fi
 
 if tput setaf 1 &> /dev/null; then
-    if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
-      MAGENTA=$(tput setaf 9)
-      ORANGE=$(tput setaf 172)
-      GREEN=$(tput setaf 190)
-      PURPLE=$(tput setaf 141)
-      WHITE=$(tput setaf 0)
-    else
-      MAGENTA=$(tput setaf 5)
-      ORANGE=$(tput setaf 4)
-      GREEN=$(tput setaf 2)
-      PURPLE=$(tput setaf 1)
-      WHITE=$(tput setaf 7)
-    fi
-    BOLD=$(tput bold)
-    RESET=$(tput sgr0)
+  if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
+    MAGENTA=$(tput setaf 9)
+    ORANGE=$(tput setaf 172)
+    GREEN=$(tput setaf 190)
+    PURPLE=$(tput setaf 141)
+    WHITE=$(tput setaf 0)
+  else
+    MAGENTA=$(tput setaf 5)
+    ORANGE=$(tput setaf 4)
+    GREEN=$(tput setaf 2)
+    PURPLE=$(tput setaf 1)
+    WHITE=$(tput setaf 7)
+  fi
+  BOLD=$(tput bold)
+  RESET=$(tput sgr0)
 else
-    MAGENTA="\033[1;31m"
-    ORANGE="\033[1;33m"
-    GREEN="\033[1;32m"
-    PURPLE="\033[1;35m"
-    WHITE="\033[1;37m"
-    BOLD=""
-    RESET="\033[m"
+  MAGENTA="\033[1;31m"
+  ORANGE="\033[1;33m"
+  GREEN="\033[1;32m"
+  PURPLE="\033[1;35m"
+  WHITE="\033[1;37m"
+  BOLD=""
+  RESET="\033[m"
 fi
 
 function parse_git_dirty {

--- a/themes/sexy/sexy.theme.sh
+++ b/themes/sexy/sexy.theme.sh
@@ -42,6 +42,9 @@ function parse_git_branch {
 
 function _omb_theme_PROMPT_COMMAND() {
   PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")\[$PURPLE\]\$(parse_git_branch)\[$WHITE\]\n\$ \[$RESET\]"
+  if [[ $CONDA_SHLVL == 1 ]]; then
+    PS1="\[${BOLD}${WHITE}\]<$(basename $CONDA_DEFAULT_ENV)> $PS1"
+  fi
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND


### PR DESCRIPTION
Added functionality to display the name of an active Conda environment for `themes/sexy`. Functionality is generalizable to all other themes.

- Edited `_omb_theme_PROMPT_COMMAND()` to check for whether a Conda environment is active (If there is a conda environment active, then `$CONDA_SHLVL == 1`)
- Resolved environment name in the `$PS1` variable by invoking `$(basename $CONDA_DEFAULT_ENV)`
- colorized it to match the theme

This is what it looks like when you activate a Conda environment, and after you deactivate a Conda environment:
![Screenshot 2022-11-29 at 06 43 48](https://user-images.githubusercontent.com/72840420/204532316-aa82f684-83d4-497c-b59b-4741e7814cc2.png)
