### PR TITLE
lib: provide a prompt function for the dirstack

### DIFF
--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -52,6 +52,9 @@ SCM_SVN_CHAR='⑆'
 SCM_NONE='NONE'
 SCM_NONE_CHAR='○'
 
+DIRSTACK_EXPAND_TILDE=${DIRSTACK_EXPAND_TILDE:=false}
+DIRSTACK_LIMIT=${DIRSTACK_LIMIT:=0}
+
 THEME_SHOW_USER_HOST=${THEME_SHOW_USER_HOST:=false}
 USER_HOST_THEME_PROMPT_PREFIX=''
 USER_HOST_THEME_PROMPT_SUFFIX=''
@@ -585,6 +588,29 @@ function aws_profile {
   fi
 }
 
+function _omb_dirstack_limit {
+    if [[ "${DIRSTACK_EXPAND_TILDE}" = true ]]; then
+      dirargs="-l"
+    fi
+    if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+      IFS=$'\n' read -r -d '' -a DIRS < <( dirs -p ${dirargs} && printf '\0' )
+    else
+      readarray -t DIRS < <(dirs -p ${dirargs})
+    fi
+    echo "${DIRS[@]:0:${DIRSTACK_LIMIT}}"
+}
+
+function dirs_prompt {
+  if [[ "${DIRSTACK_LIMIT}" -gt 0 ]]; then
+    _omb_dirstack_limit
+  else
+    if [[ "${DIRSTACK_EXPAND_TILDE}" = true ]]; then
+      dirs -l
+    else
+      dirs
+    fi
+  fi
+}
 
 # Returns true if $1 is a shell function.
 _omb_deprecate_function 20000 fn_exists _omb_util_function_exists

--- a/themes/bakke/bakke.theme.sh
+++ b/themes/bakke/bakke.theme.sh
@@ -16,7 +16,7 @@ function _omb_theme_PROMPT_COMMAND() {
     #PS1="${_omb_prompt_bold_teal}$(scm_char)${_omb_prompt_green}$(scm_prompt_info)${_omb_prompt_purple}$(_omb_prompt_print_ruby_env) ${_omb_prompt_olive}\h ${_omb_prompt_reset_color}in ${_omb_prompt_green}\w ${_omb_prompt_reset_color}\n${_omb_prompt_green}→${_omb_prompt_reset_color} "
     #PS1="\n${_omb_prompt_purple}\h: ${_omb_prompt_reset_color} ${_omb_prompt_green}\w\n${_omb_prompt_bold_teal}$(scm_char)${_omb_prompt_green}$(scm_prompt_info) ${_omb_prompt_green}→${_omb_prompt_reset_color} "
     #PS1="\n${_omb_prompt_teal}\h: ${_omb_prompt_reset_color} ${_omb_prompt_olive}\w\n${_omb_prompt_brown}$(scm_char)${_omb_prompt_brown}$(scm_prompt_info) ${_omb_prompt_green}→${_omb_prompt_reset_color} "
-    PS1="\n${_omb_prompt_teal}\h: ${_omb_prompt_reset_color} ${_omb_prompt_olive}\w ${_omb_prompt_green}$(scm_prompt_info)\n${_omb_prompt_reset_color}→ "
+    PS1="\n${_omb_prompt_teal}\h: ${_omb_prompt_reset_color} ${_omb_prompt_olive}$(dirs_prompt) ${_omb_prompt_green}$(scm_prompt_info)\n${_omb_prompt_reset_color}→ "
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND


### PR DESCRIPTION
Providing this additional function for prompts allows anyone using pushd/popd/dirs to navigate directory trees to quickly view their stack and find which entry they want to switch to.

This degrades gracefully for anyone not using the directory stack since dirs will always display the same as `\w` when the stack is only one entry deep.

The bakke theme has been tweaked to use the new function as an example.

Signed-off-by: Joe MacDonald <joe@deserted.net>

For what it looks like when it use, I'm adding a screenshot here.

![2022-12-06-123744_3840x1080_scrot](https://user-images.githubusercontent.com/74449/205985105-cbbcf802-d6b7-4ada-9c4a-c62b6aaf4ab4.png)
