### PR TITLE
fixes in xterm plugin to make it work

### DIFF
--- a/plugins/xterm/xterm.plugin.bash
+++ b/plugins/xterm/xterm.plugin.bash
@@ -27,7 +27,7 @@ function _omb_plugin_xterm_short_command {
 }
 
 function _omb_plugin_xterm_set_title {
-  local title=${1:-xterm}
+  local title=${1:-terminal}
   printf '\e]0;%s\e\\' "$title"
 }
 

--- a/plugins/xterm/xterm.plugin.bash
+++ b/plugins/xterm/xterm.plugin.bash
@@ -12,7 +12,7 @@ _omb_module_require plugin:bash-preexec
 
 function _omb_plugin_xterm_short_dirname {
   local dir_name=${PWD/~/\~}
-  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE:-} == true ]] && ((${#dir_name} > 8)); then
+  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE-} == true ]] && ((${#dir_name} > 8)); then
     dir_name=${dir_name##*/}
   fi
   echo "$dir_name"
@@ -20,7 +20,7 @@ function _omb_plugin_xterm_short_dirname {
 
 function _omb_plugin_xterm_short_command {
   local input_command="$*"
-  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE:-} == true ]] && ((${#input_command} > 8)); then
+  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE-} == true ]] && ((${#input_command} > 8)); then
     input_command=${input_command%% *}
   fi
   echo "$input_command"

--- a/plugins/xterm/xterm.plugin.bash
+++ b/plugins/xterm/xterm.plugin.bash
@@ -12,7 +12,7 @@ _omb_module_require plugin:bash-preexec
 
 function _omb_plugin_xterm_short_dirname {
   local dir_name=${PWD/~/\~}
-  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE-} == true ]] && ((${#dir_name} > 8)); then
+  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE:-} == true ]] && ((${#dir_name} > 8)); then
     dir_name=${dir_name##*/}
   fi
   echo "$dir_name"
@@ -20,14 +20,14 @@ function _omb_plugin_xterm_short_dirname {
 
 function _omb_plugin_xterm_short_command {
   local input_command="$*"
-  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE-} == true ]] ((${#input_command} > 8)); then
+  if [[ ${OMB_PLUGIN_XTERM_SHORT_TERM_LINE:-} == true ]] && ((${#input_command} > 8)); then
     input_command=${input_command%% *}
   fi
   echo "$input_command"
 }
 
 function _omb_plugin_xterm_set_title {
-  local title=${1-}
+  local title=${1:-xterm}
   printf '\e]0;%s\e\\' "$title"
 }
 


### PR DESCRIPTION
On ubuntu 20 LTS I was getting syntax error (line 23) when the plugin was activated.
I fixed set-title sequence (to ESC0;titleBEL), where ESC is \e (or \033) and BEL is \a (or \007).