### PR TITLE
Allow CASE_SENSITIVE and HYPHEN_INSENSITIVE to work as documented

### DIFF
--- a/lib/shopt.sh
+++ b/lib/shopt.sh
@@ -46,7 +46,13 @@ else
 
 	# Treat hyphens and underscores as equivalent
 	# CASE_SENSITIVE must be off
-	if [[ ${OMB_HYPHEN_INSENSITIVE:-${HYPHEN_INSENSITIVE:-false}} == true ]]; then
+	if [[ ! ${OMB_HYPHEN_SENSITIVE-} && ${HYPHEN_INSENSITIVE} ]]; then
+		case $HYPHEN_INSENSITIVE in
+		(true)  OMB_HYPHEN_SENSITIVE=true ;;
+		(false) OMB_HYPHEN_SENSITIVE=false ;;
+		esac
+	fi
+	if [[ ${OMB_HYPHEN_SENSITIVE-} == false ]]; then
 		bind "set completion-map-case on"
 	fi
 fi

--- a/lib/shopt.sh
+++ b/lib/shopt.sh
@@ -43,10 +43,13 @@ if [[ ${OMB_CASE_SENSITIVE:-${CASE_SENSITIVE:-}} == true ]]; then
 else
 	# By default, case sensitivity is disabled.
 	bind "set completion-ignore-case on"
-fi
 
-# Treat hyphens and underscores as equivalent
-bind "set completion-map-case on"
+	# Treat hyphens and underscores as equivalent
+	# CASE_SENSITIVE must be off
+	if [[ ${OMB_HYPHEN_INSENSITIVE:-${HYPHEN_INSENSITIVE:-false}} == true ]]; then
+		bind "set completion-map-case on"
+	fi
+fi
 
 # Display matches for ambiguous patterns at first tab press
 bind "set show-all-if-ambiguous on"

--- a/templates/bashrc.osh-template
+++ b/templates/bashrc.osh-template
@@ -16,7 +16,7 @@ OSH_THEME="font"
 
 # Uncomment the following line to use hyphen-insensitive completion. Case
 # sensitive completion must be off. _ and - will be interchangeable.
-# OMB_HYPHEN_INSENSITIVE="true"
+# OMB_HYPHEN_SENSITIVE="false"
 
 # Uncomment the following line to disable bi-weekly auto-update checks.
 # DISABLE_AUTO_UPDATE="true"

--- a/templates/bashrc.osh-template
+++ b/templates/bashrc.osh-template
@@ -16,7 +16,7 @@ OSH_THEME="font"
 
 # Uncomment the following line to use hyphen-insensitive completion. Case
 # sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
+# OMB_HYPHEN_INSENSITIVE="true"
 
 # Uncomment the following line to disable bi-weekly auto-update checks.
 # DISABLE_AUTO_UPDATE="true"


### PR DESCRIPTION
Adjusted shopt.sh to use CASE_SENSITIVe and HYPHEN_INSENSITIVE variables to affect completion.

Note, this changes the old default hyphen insensitive completion behavior, the user will need to set HYPHEN_INSENSITIVE="true" to have the old default behavior