### PR TITLE
omb-prompt-base: Add "." to git branch whitelist

### DIFF
--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -170,7 +170,7 @@ function scm_prompt_info_common {
 function git_clean_branch {
   local unsafe_ref=$(command git symbolic-ref -q HEAD 2> /dev/null)
   local stripped_ref=${unsafe_ref##refs/heads/}
-  local clean_ref=${stripped_ref//[^a-zA-Z0-9\/_]/-}
+  local clean_ref=${stripped_ref//[^a-zA-Z0-9\/_\.]/-}
   echo $clean_ref
 }
 

--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -170,7 +170,8 @@ function scm_prompt_info_common {
 function git_clean_branch {
   local unsafe_ref=$(command git symbolic-ref -q HEAD 2> /dev/null)
   local stripped_ref=${unsafe_ref##refs/heads/}
-  local clean_ref=${stripped_ref//[^a-zA-Z0-9\/_\.]/-}
+  local clean_ref=${stripped_ref//[\$\`\\]/-}
+  clean_ref=${clean_ref//[^[:print:]]/-} # strip escape sequences, etc.
   echo $clean_ref
 }
 


### PR DESCRIPTION
Add "." to the git branch character whitelist to fix branches like v6.0 or 5.4.2, as examples.

I'm working with a branch that is called "toradex_5.4-2.3.x-imx" from the linux-toradex repo. It was get renamed to "toradex_5-4-2-3-x-imx", which is very annoying. This also passed the https://github.com/njhartwell/pw3nage test.