### PR TITLE
Removed redundant shopt command (histappend)

### DIFF
--- a/lib/history.sh
+++ b/lib/history.sh
@@ -1,5 +1,4 @@
 #! bash oh-my-bash.module
-shopt -s histappend # append to bash_history if Terminal.app quits
 
 ## Command history configuration
 if [ -z "$HISTFILE" ]; then


### PR DESCRIPTION
`shopt -s histappend` is executed twice in `lib/history.sh` with just 12 lines in between, which do not really do anything but define a single variable (`HISTFILE`). No reason to have this twice:

```bash
$ grep -n 'shopt -s histappend' ~/.oh-my-bash/lib/history.sh
2:shopt -s histappend # append to bash_history if Terminal.app quits
14:shopt -s histappend
$
```