### PR TITLE
Removing redundant HISTIGNORE patterns

### DIFF
--- a/lib/history.sh
+++ b/lib/history.sh
@@ -37,7 +37,7 @@ export HISTFILESIZE=
 HISTCONTROL="erasedups:ignoreboth"
 
 # Don't record some commands
-export HISTIGNORE="&:[ ]*:exit:ls:bg:fg:history:clear"
+export HISTIGNORE="exit:ls:bg:fg:history:clear"
 
 # Enable incremental history search with up/down arrows (also Readline goodness)
 # Learn more about this here: http://codeinthehole.com/writing/the-most-important-command-line-tip-incremental-hi


### PR DESCRIPTION
OMB currently sets in `lib/history.sh`:

```
# Avoid duplicate entries
HISTCONTROL="erasedups:ignoreboth"

# Don't record some commands
export HISTIGNORE="&:[ ]*:exit:ls:bg:fg:history:clear"
```

According to [official GNU bash manual](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-HISTIGNORE), having `&:[ ]*` in `HISTIGNORE` provides the functionality of `ignoreboth`. Thus, having both provides redundant results but makes the config harder to understand.