### PR TITLE
agnoster theam out of box reports "command not found"

### DIFF
--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -341,8 +341,8 @@ function prompt_git {
   local ref dirty
   if command git rev-parse --is-inside-work-tree &>/dev/null; then
     ZSH_THEME_GIT_PROMPT_DIRTY='±'
-    dirty=$(command git_status_dirty)
-    stash=$(command git_stash_dirty)
+    dirty=$(git_status_dirty)
+    stash=$(git_stash_dirty)
     ref=$(command git symbolic-ref HEAD 2> /dev/null) ||
       ref="➦ $(command git describe --exact-match --tags HEAD 2> /dev/null)" ||
       ref="➦ $(command git show-ref --head -s --abbrev | head -n1 2> /dev/null)"

--- a/themes/doubletime/doubletime.theme.sh
+++ b/themes/doubletime/doubletime.theme.sh
@@ -33,7 +33,7 @@ function doubletime_scm_prompt {
   if [ $CHAR = $SCM_NONE_CHAR ]; then
     return
   elif [ $CHAR = $SCM_GIT_CHAR ]; then
-    echo "$(command git_prompt_status)"
+    echo "$(git_prompt_status)"
   else
     echo "[$(scm_prompt_info)]"
   fi


### PR DESCRIPTION
```c++
bash: git_status_dirty: command not found
bash: git_stash_dirty: command not found
```

git_status_dirty and git_stash_dirty are functions and not external command but are internal functions in given file.
