### PR TITLE
omb-prompt-base: do not attempt to process git vars outside a git tree

### DIFF
--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -237,6 +237,7 @@ function git_status_summary {
 function git_prompt_vars {
   local details=''
   local git_status_flags=''
+  [[ "$(command git rev-parse --is-inside-work-tree 2> /dev/null)" == "true" ]] || return 1
   SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
   if [[ "$(command git config --get bash-it.hide-status)" != "1" ]]; then
     [[ "${SCM_GIT_IGNORE_UNTRACKED}" = "true" ]] && git_status_flags='-uno'


### PR DESCRIPTION
I noticed this when checking out the n0qorg, being outside a git repository would have an undecorated `detached:` (from `SCM_THEME_DETACHED_PREFIX`) in the prompt.  It's easy enough to correct this in the theme but since the problem also may be observed in hawaii50, iterate, pro, standard and zitron as well, and `git rev-parse` is fast to execute anyway, this seems to be the correct place to insert this quick check.
