### PR TITLE
Add a newline prefix to optimize the display of outputs without EOL

### DIFF
--- a/themes/axin/axin.theme.sh
+++ b/themes/axin/axin.theme.sh
@@ -29,7 +29,7 @@ OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
 function _omb_theme_PROMPT_COMMAND() {
   local python_venv
   _omb_prompt_get_python_venv
-  PS1="$python_venv${MAGENTA}\u ${WHITE}@ ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}$SCM_THEME_PROMPT_PREFIX$(clock_prompt) ${PURPLE}\$(scm_prompt_info) \n\$ ${RESET}"
+  PS1="\n$python_venv${MAGENTA}\u ${WHITE}@ ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}$SCM_THEME_PROMPT_PREFIX$(clock_prompt) ${PURPLE}\$(scm_prompt_info) \n\$ ${RESET}"
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"${_omb_prompt_white}"}


### PR DESCRIPTION
Before
![image](https://github.com/ohmybash/oh-my-bash/assets/30486766/924b8e2d-31c0-432b-b15c-54a805464289)
