### PR TITLE
aliases/cd: break the cd aliases into a separate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ $ EDIT "$OSH_CUSTOM/themes/agnoster/agnoster.theme.sh"
 
 If you would like to track the upstream changes for your customized version of modules, you can optionally directly edit the original files and commit them.  In this case, you need to handle possible conflicts with the upstream in upgrading.
 
-If you would like to replace an existing module (theme/plugin/aliases/complet) bundled with Oh My Bash, create a module of the same name in the `custom/` directory so that it will be loaded instead of the original one.
+If you would like to replace an existing module (theme/plugin/aliases/completion) bundled with Oh My Bash, create a module of the same name in the `custom/` directory so that it will be loaded instead of the original one.
 
 ### Configuration
 

--- a/aliases/README.md
+++ b/aliases/README.md
@@ -1,5 +1,37 @@
 # aliases
 
+## alias:cd
+
+Handy aliases for directory navigation commands using pushd/popd.
+To activate it, add cd to plugins(...) in your .bashrc file:
+
+plugins=(... cd)
+
+| Alias       | Command∗                     |
+| ----------- | ---------------------------- |
+| `cd <dir>`  | `pushd <dir>`                |
+| `cd..`      | `pushd ..`                   |
+| `..`        | `pushd ..`                   |
+| `...`       | `pushd ../..`                |
+| `.3`        | `pushd ../../../`            |
+| `.4`        | `pushd ../../../../`         |
+| `.5`        | `pushd ../../../../../`      |
+| `.6`        | `pushd ../../../../../../`   |
+| `-`         | `cd -`                       |
+| `1`         | `cd -1`                      |
+| `2`         | `cd -2`                      |
+| `3`         | `cd -3`                      |
+| `4`         | `cd -4`                      |
+| `5`         | `cd -5`                      |
+| `6`         | `cd -6`                      |
+| `7`         | `cd -7`                      |
+| `8`         | `cd -8`                      |
+| `9`         | `cd -9`                      |
+
+∗ The summary table above shows the aliases and the effective command
+  it corresponds to, however the real command is a function that better
+  manages the directory stack than simple pushd/popd operations.
+
 ## alias:debian
 
 Shorted aliases for most used Debian specific commands.

--- a/aliases/cd.aliases.sh
+++ b/aliases/cd.aliases.sh
@@ -1,0 +1,49 @@
+#! bash oh-my-bash.module
+#  ---------------------------------------------------------------------------
+
+# A clone of the Zsh `cd' builtin command.  This supports the numbered option
+# `-1', `-2', etc.
+function _omb_directories_cd {
+  local oldpwd=$OLDPWD
+  local -i index
+  if [[ $# -eq 1 && $1 =~ ^-[1-9]+$ ]]; then
+    index=${1#-}
+    if ((index >= ${#DIRSTACK[@]})); then
+      builtin echo "cd: no such entry in dir stack" >&2
+      return 1
+    fi
+    set -- "${DIRSTACK[index]}"
+  fi
+  builtin pushd . >/dev/null &&
+    OLDPWD=$oldpwd builtin cd "$@" &&
+    oldpwd=$OLDPWD &&
+    builtin pushd . >/dev/null &&
+    for ((index = ${#DIRSTACK[@]} - 1; index >= 1; index--)); do
+      if [[ ${DIRSTACK[0]/#~/$HOME} == "${DIRSTACK[index]}" ]]; then
+        builtin popd "+$index" >/dev/null || return 1
+      fi
+    done
+  OLDPWD=$oldpwd
+}
+
+_omb_util_alias cd='_omb_directories_cd'
+
+_omb_util_alias cd..='cd ../'                         # Go back 1 directory level (for fast typers)
+_omb_util_alias ..='cd ../'                           # Go back 1 directory level
+_omb_util_alias ...='cd ../../'                       # Go back 2 directory levels
+_omb_util_alias .3='cd ../../../'                     # Go back 3 directory levels
+_omb_util_alias .4='cd ../../../../'                  # Go back 4 directory levels
+_omb_util_alias .5='cd ../../../../../'               # Go back 5 directory levels
+_omb_util_alias .6='cd ../../../../../../'            # Go back 6 directory levels
+
+_omb_util_alias -='cd -'
+_omb_util_alias 1='cd -'
+_omb_util_alias 2='cd -2'
+_omb_util_alias 3='cd -3'
+_omb_util_alias 4='cd -4'
+_omb_util_alias 5='cd -5'
+_omb_util_alias 6='cd -6'
+_omb_util_alias 7='cd -7'
+_omb_util_alias 8='cd -8'
+_omb_util_alias 9='cd -9'
+

--- a/lib/directories.sh
+++ b/lib/directories.sh
@@ -1,51 +1,6 @@
 #! bash oh-my-bash.module
 # Common directories functions
 
-# A clone of the Zsh `cd' builtin command.  This supports the numbered option
-# `-1', `-2', etc.
-function _omb_directories_cd {
-  local oldpwd=$OLDPWD
-  local -i index
-  if [[ $# -eq 1 && $1 =~ ^-[1-9]+$ ]]; then
-    index=${1#-}
-    if ((index >= ${#DIRSTACK[@]})); then
-      builtin echo "cd: no such entry in dir stack" >&2
-      return 1
-    fi
-    set -- "${DIRSTACK[index]}"
-  fi
-  builtin pushd . >/dev/null &&
-    OLDPWD=$oldpwd builtin cd "$@" &&
-    oldpwd=$OLDPWD &&
-    builtin pushd . >/dev/null &&
-    for ((index = ${#DIRSTACK[@]} - 1; index >= 1; index--)); do
-      if [[ ${DIRSTACK[0]/#~/$HOME} == "${DIRSTACK[index]}" ]]; then
-        builtin popd "+$index" >/dev/null || return 1
-      fi
-    done
-  OLDPWD=$oldpwd
-}
-_omb_util_alias cd='_omb_directories_cd'
-
-_omb_util_alias cd..='cd ../'                         # Go back 1 directory level (for fast typers)
-_omb_util_alias ..='cd ../'                           # Go back 1 directory level
-_omb_util_alias ...='cd ../../'                       # Go back 2 directory levels
-_omb_util_alias .3='cd ../../../'                     # Go back 3 directory levels
-_omb_util_alias .4='cd ../../../../'                  # Go back 4 directory levels
-_omb_util_alias .5='cd ../../../../../'               # Go back 5 directory levels
-_omb_util_alias .6='cd ../../../../../../'            # Go back 6 directory levels
-
-_omb_util_alias -='cd -'
-_omb_util_alias 1='cd -'
-_omb_util_alias 2='cd -2'
-_omb_util_alias 3='cd -3'
-_omb_util_alias 4='cd -4'
-_omb_util_alias 5='cd -5'
-_omb_util_alias 6='cd -6'
-_omb_util_alias 7='cd -7'
-_omb_util_alias 8='cd -8'
-_omb_util_alias 9='cd -9'
-
 _omb_util_alias md='mkdir -p'
 _omb_util_alias rd='rmdir'
 _omb_util_alias d='dirs -v | head -10'

--- a/templates/bashrc.osh-template
+++ b/templates/bashrc.osh-template
@@ -91,6 +91,7 @@ completions=(
 # Example format: aliases=(vagrant composer git-avh)
 # Add wisely, as too many aliases slow down shell startup.
 aliases=(
+  cd
   general
 )
 


### PR DESCRIPTION
Aliasing `cd` to a function that manipulates DIRSTACK is surprising to anyone who already incorporates DIRSTACK operations in their workflow. Breaking this alias out into a separate module allows such people to turn off the aliasing.  Leaving the module enabled by default preserves the existing behaviour for current omb users.