### PR TITLE
themes/agnoster : pyenv not properly detected/shown

### DIFF
--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -301,20 +301,12 @@ function prompt_virtualenv {
 function prompt_pyenv {
   if [[ $PYENV_VIRTUALENV_INIT == 1 ]] && _omb_util_binary_exists pyenv; then
     # Priority is shell > local > global
-    local PYENV_SHELL=$(pyenv shell 2>&1)
-    local PYENV_LOCAL=$(pyenv local 2>&1)
-    local PYENV_GLOBAL=$(pyenv global 2>&1)
-    # pyenv shell is not set
-    if [[ "$PYENV_SHELL" == *"pyenv: no shell-specific version configured"* ]]; then
-      # Check if pyenv local is set
-      if [[ "$PYENV_LOCAL" == *"pyenv: no local version configured"* ]]; then
-        # Neither are set, we're using the global version
-        local PYENV_VERSION=$PYENV_GLOBAL
-      else
-        local PYENV_VERSION=$PYENV_LOCAL
-      fi
+    # When pyenv shell is set, the environment variable $PYENV_VERSION is set with the value we want
+    if [[ -n $PYENV_VERSION ]]; then
+      local PYENV_VERSION="$PYENV_VERSION"
+      # Otherwise, fall back to pyenv local/global to get the version
     else
-      local PYENV_VERSION=$PYENV_SHELL
+      local PYENV_VERSION=$(pyenv local 2>/dev/null || pyenv global 2>/dev/null)
     fi
     # If it is not the system's python, then display additional info
     if [[ "$PYENV_VERSION" != "system" ]]; then

--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -284,7 +284,7 @@ function prompt_end {
 ### virtualenv prompt
 function prompt_virtualenv {
   # Exclude pyenv
-  if [[ -d $VIRTUAL_ENV ]] && [[ $PYENV_VIRTUALENV_INIT != 1 ]]; then
+  if [[ -d $VIRTUAL_ENV && $PYENV_VIRTUALENV_INIT != 1 ]]; then
     # Python could output the version information in both stdout and
     # stderr (e.g. if using pyenv, the output goes to stderr).
     local VERSION_OUTPUT=$("$VIRTUAL_ENV"/bin/python --version 2>&1)
@@ -299,7 +299,7 @@ function prompt_virtualenv {
 
 ### pyenv prompt
 function prompt_pyenv {
-  if [[ $PYENV_VIRTUALENV_INIT == 1 ]]; then
+  if [[ $PYENV_VIRTUALENV_INIT == 1 ]] && _omb_util_binary_exists pyenv; then
     # Priority is shell > local > global
     local PYENV_SHELL=$(pyenv shell 2>&1)
     local PYENV_LOCAL=$(pyenv local 2>&1)

--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -284,7 +284,9 @@ function prompt_end {
 ### virtualenv prompt
 function prompt_virtualenv {
   # Exclude pyenv
-  if [[ -d $VIRTUAL_ENV && $PYENV_VIRTUALENV_INIT != 1 ]]; then
+  [[ $PYENV_VIRTUALENV_INIT == 1 ]] && _omb_util_binary_exists pyenv && return 0
+
+  if [[ -d $VIRTUAL_ENV ]]; then
     # Python could output the version information in both stdout and
     # stderr (e.g. if using pyenv, the output goes to stderr).
     local VERSION_OUTPUT=$("$VIRTUAL_ENV"/bin/python --version 2>&1)
@@ -302,10 +304,8 @@ function prompt_pyenv {
   if [[ $PYENV_VIRTUALENV_INIT == 1 ]] && _omb_util_binary_exists pyenv; then
     # Priority is shell > local > global
     # When pyenv shell is set, the environment variable $PYENV_VERSION is set with the value we want
-    if [[ -n $PYENV_VERSION ]]; then
-      local PYENV_VERSION="$PYENV_VERSION"
-      # Otherwise, fall back to pyenv local/global to get the version
-    else
+    if [[ ! ${PYENV_VERSION-} ]]; then
+      # If not set, fall back to pyenv local/global to get the version
       local PYENV_VERSION=$(pyenv local 2>/dev/null || pyenv global 2>/dev/null)
     fi
     # If it is not the system's python, then display additional info


### PR DESCRIPTION
At the moment, agnoster relies on `$VIRTUAL_ENV` to detect virtualenvs, but it is unreliable when using pyenv. With a named pyenv virtualenv, it properly detects we are in a virtualenv, and sets the prompt as `[v] <version>`; when using a non-system version, it fails to detect the version (`$VIRTUAL_ENV` is not set) and hides the python segment.

Ideally (I think), pyenv should be treated and displayed somewhat like conda is: when a non system version is used, grab the python version, and when in a virtualenv, show its name and version.

This PR adds Pyenv detection to agnoster:

 - if pyenv is not initialized, fall back to the virtualenv detection
 - when pyenv is set to a version other than "system", show the version number
 - when pyenv is in virtulenv mode, also display the virtualenv's name

I'm not particularly proficient with bash, so the whole thing can probably be improved, but as far as I could test, it works. Since I don't use conda, it would likely require some extra testing to see how the two interact and check that it doesn't break the conda display.