### PR TITLE
Update rake.completion.sh to list all tasks

### DIFF
--- a/completions/rake.completion.sh
+++ b/completions/rake.completion.sh
@@ -7,7 +7,7 @@ function _rakecomplete {
     if [ -f Rakefile ]; then
         recent=`ls -t .rake_tasks~ Rakefile **/*.rake 2> /dev/null | head -n 1`
         if [[ $recent != '.rake_tasks~' ]]; then
-            rake --silent --tasks | cut -d " " -f 2 > .rake_tasks~
+            rake --silent --tasks --all | cut -d " " -f 2 > .rake_tasks~
         fi
         COMPREPLY=($(compgen -W "`cat .rake_tasks~`" -- ${COMP_WORDS[COMP_CWORD]}))
         return 0


### PR DESCRIPTION
My rake (13.0.6) generates empty list for completition without the flag `--all`