### PR TITLE
lib/git: Fix problems caused by uses of Zsh features

### DIFF
--- a/completions/gh.completion.sh
+++ b/completions/gh.completion.sh
@@ -322,7 +322,7 @@ EOF
       format=${format//\p/\2}
       format=${format//\o/\3}
     fi
-    command git config --get-regexp 'remote\.[^.]*\.url' |
+    _omb_prompt_git config --get-regexp 'remote\.[^.]*\.url' |
     grep -E ' ((https?|git)://|git@)github\.com[:/][^:/]+/[^/]+$' |
     sed -E 's#^remote\.([^.]+)\.url +.+[:/](([^/]+)/[^.]+)(\.git)?$#'"$format"'#'
   }
@@ -332,12 +332,12 @@ EOF
   function __hub_heads {
     local i remote repo branch dir=$(__gitdir)
     if [ -d "$dir" ]; then
-      command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+      _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
         "refs/heads/"
       for i in $(__hub_github_repos); do
         remote=${i%%:*}
         repo=${i#*:}
-        command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+        _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
           "refs/remotes/${remote}/" | while read branch; do
           echo "${repo}:${branch#${remote}/}"
         done
@@ -351,11 +351,11 @@ EOF
   function __hub_revlist {
     local i remote=${1:-origin} dir=$(__gitdir)
     if [ -d "$dir" ]; then
-      command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+      _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
         "refs/remotes/${remote}/" | while read i; do
         echo "${i#${remote}/}"
       done
-      command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+      _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
         "refs/tags/"
     fi
   }

--- a/completions/git_flow.completion.sh
+++ b/completions/git_flow.completion.sh
@@ -107,17 +107,17 @@ __git_flow_feature ()
 
 __git_flow_list_features ()
 {
-	git flow feature list 2> /dev/null | tr -d ' |*'
+	_omb_prompt_git flow feature list 2> /dev/null | tr -d ' |*'
 }
 
 __git_flow_list_remote_features ()
 {
-	git branch -r 2> /dev/null | grep "origin/$(__git_flow_feature_prefix)" | awk '{ sub(/^origin\/$(__git_flow_feature_prefix)/, "", $1); print }'
+	_omb_prompt_git branch -r 2> /dev/null | grep "origin/$(__git_flow_feature_prefix)" | awk '{ sub(/^origin\/$(__git_flow_feature_prefix)/, "", $1); print }'
 }
 
 __git_flow_feature_prefix ()
 {
-	git config gitflow.prefix.feature 2> /dev/null || echo "feature/"
+	_omb_prompt_git config gitflow.prefix.feature 2> /dev/null || echo "feature/"
 }
 
 __git_flow_release ()
@@ -143,7 +143,7 @@ __git_flow_release ()
 
 __git_flow_list_releases ()
 {
-	git flow release list 2> /dev/null
+	_omb_prompt_git flow release list 2> /dev/null
 }
 
 __git_flow_hotfix ()
@@ -168,7 +168,7 @@ __git_flow_hotfix ()
 
 __git_flow_list_hotfixes ()
 {
-	git flow hotfix list 2> /dev/null
+	_omb_prompt_git flow hotfix list 2> /dev/null
 }
 
 # temporarily wrap __git_find_on_cmdline() for backwards compatibility

--- a/completions/git_flow_avh.completion.sh
+++ b/completions/git_flow_avh.completion.sh
@@ -454,7 +454,7 @@ __git_flow_prefix ()
 {
 	case "$1" in
 	feature|release|hotfix|support)
-		git config "gitflow.prefix.$1" 2> /dev/null || echo "$1/"
+		_omb_prompt_git config "gitflow.prefix.$1" 2> /dev/null || echo "$1/"
 		return
 		;;
 	esac
@@ -464,14 +464,14 @@ __git_flow_list_local_branches ()
 {
 	if [ -n "$1" ]; then
 		local prefix="$(__git_flow_prefix $1)"
-		git for-each-ref --shell --format="ref=%(refname:short)" refs/heads/$prefix | \
+		_omb_prompt_git for-each-ref --shell --format="ref=%(refname:short)" refs/heads/$prefix | \
 			while read -r entry; do
 				eval "$entry"
 				ref="${ref#$prefix}"
 				echo "$ref"
 			done | sort
 	else
-		git for-each-ref --format="ref=%(refname:short)" refs/heads/ | sort
+		_omb_prompt_git for-each-ref --format="ref=%(refname:short)" refs/heads/ | sort
 
 	fi
 }
@@ -479,8 +479,8 @@ __git_flow_list_local_branches ()
 __git_flow_list_remote_branches ()
 {
 	local prefix="$(__git_flow_prefix $1)"
-	local origin="$(git config gitflow.origin 2> /dev/null || echo "origin")"
-	git for-each-ref --shell --format='%(refname:short)' refs/remotes/$origin/$prefix | \
+	local origin="$(_omb_prompt_git config gitflow.origin 2> /dev/null || echo "origin")"
+	_omb_prompt_git for-each-ref --shell --format='%(refname:short)' refs/remotes/$origin/$prefix | \
 			while read -r entry; do
 				eval "$entry"
 				ref="${ref##$prefix}"
@@ -490,17 +490,17 @@ __git_flow_list_remote_branches ()
 
 __git_flow_list_branches ()
 {
-	local origin="$(git config gitflow.origin 2> /dev/null || echo "origin")"
+	local origin="$(_omb_prompt_git config gitflow.origin 2> /dev/null || echo "origin")"
 	if [ -n "$1" ]; then
 		local prefix="$(__git_flow_prefix $1)"
-		git for-each-ref --shell --format="ref=%(refname:short)" refs/heads/$prefix refs/remotes/$origin/$prefix | \
+		_omb_prompt_git for-each-ref --shell --format="ref=%(refname:short)" refs/heads/$prefix refs/remotes/$origin/$prefix | \
 			while read -r entry; do
 				eval "$entry"
 				ref="${ref##$prefix}"
 				echo "$ref"
 			done | sort
 	else
-		git for-each-ref --format="%(refname:short)" refs/heads/ refs/remotes/$origin | sort
+		_omb_prompt_git for-each-ref --format="%(refname:short)" refs/heads/ refs/remotes/$origin | sort
 	fi
 }
 

--- a/completions/hub.completion.sh
+++ b/completions/hub.completion.sh
@@ -324,7 +324,7 @@ EOF
       format=${format//\p/\2}
       format=${format//\o/\3}
     fi
-    command git config --get-regexp 'remote\.[^.]*\.url' |
+    _omb_prompt_git config --get-regexp 'remote\.[^.]*\.url' |
     grep -E ' ((https?|git)://|git@)github\.com[:/][^:/]+/[^/]+$' |
     sed -E 's#^remote\.([^.]+)\.url +.+[:/](([^/]+)/[^.]+)(\.git)?$#'"$format"'#'
   }
@@ -334,12 +334,12 @@ EOF
   function __hub_heads {
     local i remote repo branch dir=$(__gitdir)
     if [ -d "$dir" ]; then
-      command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+      _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
         "refs/heads/"
       for i in $(__hub_github_repos); do
         remote=${i%%:*}
         repo=${i#*:}
-        command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+        _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
           "refs/remotes/${remote}/" | while read branch; do
           echo "${repo}:${branch#${remote}/}"
         done
@@ -353,11 +353,11 @@ EOF
   function __hub_revlist {
     local i remote=${1:-origin} dir=$(__gitdir)
     if [ -d "$dir" ]; then
-      command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+      _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
         "refs/remotes/${remote}/" | while read i; do
         echo "${i#${remote}/}"
       done
-      command git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
+      _omb_prompt_git --git-dir="$dir" for-each-ref --format='%(refname:short)' \
         "refs/tags/"
     fi
   }

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -2,14 +2,15 @@
 # Outputs current branch info in prompt format
 
 _omb_module_require lib:omb-prompt-colors
+_omb_module_require lib:omb-prompt-base
 
 # # Note: The same name of a functionis defined in omb-prompt-base.  We comment
 # # out this function for now.
 # function git_prompt_info() {
 #   local ref
-#   if [[ "$(command git config --get oh-my-bash.hide-status 2>/dev/null)" != "1" ]]; then
-#     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-#     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
+#   if [[ "$(_omb_prompt_git config --get oh-my-bash.hide-status 2>/dev/null)" != "1" ]]; then
+#     ref=$(_omb_prompt_git symbolic-ref HEAD 2> /dev/null) || \
+#     ref=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) || return 0
 #     echo "$OSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$OSH_THEME_GIT_PROMPT_SUFFIX"
 #   fi
 # }
@@ -19,14 +20,14 @@ function parse_git_dirty() {
   local STATUS=''
   local FLAGS
   FLAGS=('--porcelain')
-  if [[ "$(command git config --get oh-my-bash.hide-dirty)" != "1" ]]; then
+  if [[ "$(_omb_prompt_git config --get oh-my-bash.hide-dirty)" != "1" ]]; then
     if [[ $POST_1_7_2_GIT -gt 0 ]]; then
       FLAGS+=( '--ignore-submodules=dirty' )
     fi
     if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
       FLAGS+=( '--untracked-files=no' )
     fi
-    STATUS=$(command git status "${FLAGS[@]}" 2> /dev/null | tail -n1)
+    STATUS=$(_omb_prompt_git status "${FLAGS[@]}" 2> /dev/null | tail -n1)
   fi
   if [[ -n $STATUS ]]; then
     echo "$OSH_THEME_GIT_PROMPT_DIRTY"
@@ -38,11 +39,11 @@ function parse_git_dirty() {
 # Gets the difference between the local and remote branches
 function git_remote_status() {
     local remote ahead behind git_remote_status git_remote_status_detailed git_remote_origin
-    git_remote_origin=$(command git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)
+    git_remote_origin=$(_omb_prompt_git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)
     remote=${git_remote_origin/refs\/remotes\//}
     if [[ -n ${remote} ]]; then
-        ahead=$(command git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
-        behind=$(command git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
+        ahead=$(_omb_prompt_git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
+        behind=$(_omb_prompt_git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
 
         if [[ $ahead -eq 0 ]] && [[ $behind -eq 0 ]]; then
             git_remote_status="$OSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
@@ -71,11 +72,11 @@ function git_remote_status() {
 # it's not a symbolic ref, but in a Git repo.
 function git_current_branch() {
   local ref
-  ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null)
+  ref=$(_omb_prompt_git symbolic-ref --quiet HEAD 2> /dev/null)
   local ret=$?
   if [[ $ret != 0 ]]; then
     [[ $ret == 128 ]] && return  # no git repo.
-    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+    ref=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) || return
   fi
   echo ${ref#refs/heads/}
 }
@@ -83,8 +84,8 @@ function git_current_branch() {
 
 # Gets the number of commits ahead from remote
 function git_commits_ahead() {
-  if command git rev-parse --git-dir &>/dev/null; then
-    local commits="$(command git rev-list --count @{upstream}..HEAD)"
+  if _omb_prompt_git rev-parse --git-dir &>/dev/null; then
+    local commits="$(_omb_prompt_git rev-list --count @{upstream}..HEAD)"
     if [[ "$commits" != 0 ]]; then
       echo "$OSH_THEME_GIT_COMMITS_AHEAD_PREFIX$commits$OSH_THEME_GIT_COMMITS_AHEAD_SUFFIX"
     fi
@@ -93,8 +94,8 @@ function git_commits_ahead() {
 
 # Gets the number of commits behind remote
 function git_commits_behind() {
-  if command git rev-parse --git-dir &>/dev/null; then
-    local commits="$(command git rev-list --count HEAD..@{upstream})"
+  if _omb_prompt_git rev-parse --git-dir &>/dev/null; then
+    local commits="$(_omb_prompt_git rev-list --count HEAD..@{upstream})"
     if [[ "$commits" != 0 ]]; then
       echo "$OSH_THEME_GIT_COMMITS_BEHIND_PREFIX$commits$OSH_THEME_GIT_COMMITS_BEHIND_SUFFIX"
     fi
@@ -103,21 +104,21 @@ function git_commits_behind() {
 
 # Outputs if current branch is ahead of remote
 function git_prompt_ahead() {
-  if [[ -n "$(command git rev-list origin/$(git_current_branch)..HEAD 2> /dev/null)" ]]; then
+  if [[ -n "$(_omb_prompt_git rev-list origin/$(git_current_branch)..HEAD 2> /dev/null)" ]]; then
     echo "$OSH_THEME_GIT_PROMPT_AHEAD"
   fi
 }
 
 # Outputs if current branch is behind remote
 function git_prompt_behind() {
-  if [[ -n "$(command git rev-list HEAD..origin/$(git_current_branch) 2> /dev/null)" ]]; then
+  if [[ -n "$(_omb_prompt_git rev-list HEAD..origin/$(git_current_branch) 2> /dev/null)" ]]; then
     echo "$OSH_THEME_GIT_PROMPT_BEHIND"
   fi
 }
 
 # Outputs if current branch exists on remote or not
 function git_prompt_remote() {
-  if [[ -n "$(command git show-ref origin/$(git_current_branch) 2> /dev/null)" ]]; then
+  if [[ -n "$(_omb_prompt_git show-ref origin/$(git_current_branch) 2> /dev/null)" ]]; then
     echo "$OSH_THEME_GIT_PROMPT_REMOTE_EXISTS"
   else
     echo "$OSH_THEME_GIT_PROMPT_REMOTE_MISSING"
@@ -127,19 +128,19 @@ function git_prompt_remote() {
 # Formats prompt string for current git commit short SHA
 function git_prompt_short_sha() {
   local SHA
-  SHA=$(command git rev-parse --short HEAD 2> /dev/null) && echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
+  SHA=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) && echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
 # Formats prompt string for current git commit long SHA
 function git_prompt_long_sha() {
   local SHA
-  SHA=$(command git rev-parse HEAD 2> /dev/null) && echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
+  SHA=$(_omb_prompt_git rev-parse HEAD 2> /dev/null) && echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
 # Get the status of the working tree
 function git_prompt_status() {
   local INDEX STATUS
-  INDEX=$(command git status --porcelain -b 2> /dev/null)
+  INDEX=$(_omb_prompt_git status --porcelain -b 2> /dev/null)
   STATUS=""
   if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
     STATUS="$OSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
@@ -166,7 +167,7 @@ function git_prompt_status() {
   elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
     STATUS="$OSH_THEME_GIT_PROMPT_DELETED$STATUS"
   fi
-  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+  if $(_omb_prompt_git rev-parse --verify refs/stash >/dev/null 2>&1); then
     STATUS="$OSH_THEME_GIT_PROMPT_STASHED$STATUS"
   fi
   if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
@@ -190,7 +191,7 @@ function git_prompt_status() {
 function git_compare_version() {
   local INPUT_GIT_VERSION INSTALLED_GIT_VERSION
   INPUT_GIT_VERSION=(${(s/./)1})
-  INSTALLED_GIT_VERSION=($(command git --version 2>/dev/null))
+  INSTALLED_GIT_VERSION=($(_omb_prompt_git --version 2>/dev/null))
   INSTALLED_GIT_VERSION=(${(s/./)INSTALLED_GIT_VERSION[3]})
 
   for i in {1..3}; do
@@ -209,13 +210,13 @@ function git_compare_version() {
 # Outputs the name of the current user
 # Usage example: $(git_current_user_name)
 function git_current_user_name() {
-  command git config user.name 2>/dev/null
+  _omb_prompt_git config user.name 2>/dev/null
 }
 
 # Outputs the email of the current user
 # Usage example: $(git_current_user_email)
 function git_current_user_email() {
-  command git config user.email 2>/dev/null
+  _omb_prompt_git config user.email 2>/dev/null
 }
 
 # This is unlikely to change so make it all statically assigned

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -3,6 +3,10 @@
 
 _omb_module_require lib:omb-prompt-colors
 _omb_module_require lib:omb-prompt-base
+_omb_module_require lib:omb-deprecate
+
+: "${_omb_git_post_1_7_2:=${POST_1_7_2_GIT:-}}"
+_omb_deprecate_declare 20000 POST_1_7_2_GIT _omb_git_post_1_7_2 sync
 
 # # Note: The same name of a functionis defined in omb-prompt-base.  We comment
 # # out this function for now.
@@ -20,7 +24,7 @@ function parse_git_dirty {
   local STATUS=
   local -a FLAGS=('--porcelain')
   if [[ $(_omb_prompt_git config --get oh-my-bash.hide-dirty) != 1 ]]; then
-    if ((POST_1_7_2_GIT > 0)); then
+    if ((${_omb_git_post_1_7_2:=$(git_compare_version "1.7.2")} > 0)); then
       FLAGS+=('--ignore-submodules=dirty')
     fi
     if [[ $DISABLE_UNTRACKED_FILES_DIRTY == "true" ]]; then
@@ -209,8 +213,3 @@ function git_current_user_name {
 function git_current_user_email {
   _omb_prompt_git config user.email 2>/dev/null
 }
-
-# This is unlikely to change so make it all statically assigned
-#POST_1_7_2_GIT=$(git_compare_version "1.7.2")
-# Clean up the namespace slightly by removing the checker function
-#unset -f git_compare_version

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -38,32 +38,32 @@ function parse_git_dirty() {
 
 # Gets the difference between the local and remote branches
 function git_remote_status() {
-    local remote ahead behind git_remote_status git_remote_status_detailed git_remote_origin
-    git_remote_origin=$(_omb_prompt_git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)
-    remote=${git_remote_origin/refs\/remotes\//}
-    if [[ -n ${remote} ]]; then
-        ahead=$(_omb_prompt_git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
-        behind=$(_omb_prompt_git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
+  local remote ahead behind git_remote_status git_remote_status_detailed git_remote_origin
+  git_remote_origin=$(_omb_prompt_git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)
+  remote=${git_remote_origin/refs\/remotes\//}
+  if [[ -n ${remote} ]]; then
+    ahead=$(_omb_prompt_git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
+    behind=$(_omb_prompt_git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
 
-        if [[ $ahead -eq 0 ]] && [[ $behind -eq 0 ]]; then
-            git_remote_status="$OSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
-        elif [[ $ahead -gt 0 ]] && [[ $behind -eq 0 ]]; then
-            git_remote_status="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
-            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color"
-        elif [[ $behind -gt 0 ]] && [[ $ahead -eq 0 ]]; then
-            git_remote_status="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
-            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
-        elif [[ $ahead -gt 0 ]] && [[ $behind -gt 0 ]]; then
-            git_remote_status="$OSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
-            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
-        fi
-
-        if [[ -n $OSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
-            git_remote_status="$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
-        fi
-
-        echo $git_remote_status
+    if [[ $ahead -eq 0 ]] && [[ $behind -eq 0 ]]; then
+      git_remote_status="$OSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
+    elif [[ $ahead -gt 0 ]] && [[ $behind -eq 0 ]]; then
+      git_remote_status="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
+      git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color"
+    elif [[ $behind -gt 0 ]] && [[ $ahead -eq 0 ]]; then
+      git_remote_status="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
+      git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
+    elif [[ $ahead -gt 0 ]] && [[ $behind -gt 0 ]]; then
+      git_remote_status="$OSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
+      git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
     fi
+
+    if [[ -n $OSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
+      git_remote_status="$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
+    fi
+
+    echo $git_remote_status
+  fi
 }
 
 # Outputs the name of the current branch

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -6,9 +6,9 @@ _omb_module_require lib:omb-prompt-base
 
 # # Note: The same name of a functionis defined in omb-prompt-base.  We comment
 # # out this function for now.
-# function git_prompt_info() {
+# function git_prompt_info {
 #   local ref
-#   if [[ "$(_omb_prompt_git config --get oh-my-bash.hide-status 2>/dev/null)" != "1" ]]; then
+#   if [[ $(_omb_prompt_git config --get oh-my-bash.hide-status 2>/dev/null) != 1 ]]; then
 #     ref=$(_omb_prompt_git symbolic-ref HEAD 2> /dev/null) || \
 #     ref=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) || return 0
 #     echo "$OSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$OSH_THEME_GIT_PROMPT_SUFFIX"
@@ -16,20 +16,19 @@ _omb_module_require lib:omb-prompt-base
 # }
 
 # Checks if working tree is dirty
-function parse_git_dirty() {
-  local STATUS=''
-  local FLAGS
-  FLAGS=('--porcelain')
-  if [[ "$(_omb_prompt_git config --get oh-my-bash.hide-dirty)" != "1" ]]; then
-    if [[ $POST_1_7_2_GIT -gt 0 ]]; then
-      FLAGS+=( '--ignore-submodules=dirty' )
+function parse_git_dirty {
+  local STATUS=
+  local -a FLAGS=('--porcelain')
+  if [[ $(_omb_prompt_git config --get oh-my-bash.hide-dirty) != 1 ]]; then
+    if ((POST_1_7_2_GIT > 0)); then
+      FLAGS+=('--ignore-submodules=dirty')
     fi
-    if [[ "$DISABLE_UNTRACKED_FILES_DIRTY" == "true" ]]; then
-      FLAGS+=( '--untracked-files=no' )
+    if [[ $DISABLE_UNTRACKED_FILES_DIRTY == "true" ]]; then
+      FLAGS+=('--untracked-files=no')
     fi
     STATUS=$(_omb_prompt_git status "${FLAGS[@]}" 2> /dev/null | tail -n1)
   fi
-  if [[ -n $STATUS ]]; then
+  if [[ $STATUS ]]; then
     echo "$OSH_THEME_GIT_PROMPT_DIRTY"
   else
     echo "$OSH_THEME_GIT_PROMPT_CLEAN"
@@ -37,32 +36,32 @@ function parse_git_dirty() {
 }
 
 # Gets the difference between the local and remote branches
-function git_remote_status() {
-  local remote ahead behind git_remote_status git_remote_status_detailed git_remote_origin
-  git_remote_origin=$(_omb_prompt_git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)
-  remote=${git_remote_origin/refs\/remotes\//}
-  if [[ -n ${remote} ]]; then
-    ahead=$(_omb_prompt_git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
-    behind=$(_omb_prompt_git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
+function git_remote_status {
+  local git_remote_origin=$(_omb_prompt_git rev-parse --verify ${hook_com[branch]}@{upstream} --symbolic-full-name 2>/dev/null)
+  local remote=${git_remote_origin/refs\/remotes\//}
+  if [[ $remote ]]; then
+    local ahead=$(_omb_prompt_git rev-list ${hook_com[branch]}@{upstream}..HEAD 2>/dev/null | wc -l)
+    local behind=$(_omb_prompt_git rev-list HEAD..${hook_com[branch]}@{upstream} 2>/dev/null | wc -l)
 
-    if [[ $ahead -eq 0 ]] && [[ $behind -eq 0 ]]; then
-      git_remote_status="$OSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
-    elif [[ $ahead -gt 0 ]] && [[ $behind -eq 0 ]]; then
-      git_remote_status="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
-      git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color"
-    elif [[ $behind -gt 0 ]] && [[ $ahead -eq 0 ]]; then
-      git_remote_status="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
-      git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
-    elif [[ $ahead -gt 0 ]] && [[ $behind -gt 0 ]]; then
-      git_remote_status="$OSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
-      git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
+    local git_remote_status git_remote_status_detailed
+    if ((ahead == 0 && behind == 0)); then
+      git_remote_status=$OSH_THEME_GIT_PROMPT_EQUAL_REMOTE
+    elif ((ahead > 0 && behind == 0)); then
+      git_remote_status=$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE
+      git_remote_status_detailed=$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color
+    elif ((behind > 0 && ahead == 0)); then
+      git_remote_status=$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE
+      git_remote_status_detailed=$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color
+    elif ((ahead > 0 && behind > 0)); then
+      git_remote_status=$OSH_THEME_GIT_PROMPT_DIVERGED_REMOTE
+      git_remote_status_detailed=$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color
     fi
 
-    if [[ -n $OSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
-      git_remote_status="$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX"
+    if [[ $OSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
+      git_remote_status=$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_PREFIX$remote$git_remote_status_detailed$OSH_THEME_GIT_PROMPT_REMOTE_STATUS_SUFFIX
     fi
 
-    echo $git_remote_status
+    echo "$git_remote_status"
   fi
 }
 
@@ -70,7 +69,7 @@ function git_remote_status() {
 # Usage example: git pull origin $(git_current_branch)
 # Using '--quiet' with 'symbolic-ref' will not cause a fatal error (128) if
 # it's not a symbolic ref, but in a Git repo.
-function git_current_branch() {
+function git_current_branch {
   local ref
   ref=$(_omb_prompt_git symbolic-ref --quiet HEAD 2> /dev/null)
   local ret=$?
@@ -83,42 +82,42 @@ function git_current_branch() {
 
 
 # Gets the number of commits ahead from remote
-function git_commits_ahead() {
+function git_commits_ahead {
   if _omb_prompt_git rev-parse --git-dir &>/dev/null; then
-    local commits="$(_omb_prompt_git rev-list --count @{upstream}..HEAD)"
-    if [[ "$commits" != 0 ]]; then
+    local commits=$(_omb_prompt_git rev-list --count @{upstream}..HEAD)
+    if ((commits != 0)); then
       echo "$OSH_THEME_GIT_COMMITS_AHEAD_PREFIX$commits$OSH_THEME_GIT_COMMITS_AHEAD_SUFFIX"
     fi
   fi
 }
 
 # Gets the number of commits behind remote
-function git_commits_behind() {
+function git_commits_behind {
   if _omb_prompt_git rev-parse --git-dir &>/dev/null; then
-    local commits="$(_omb_prompt_git rev-list --count HEAD..@{upstream})"
-    if [[ "$commits" != 0 ]]; then
+    local commits=$(_omb_prompt_git rev-list --count HEAD..@{upstream})
+    if ((commits != 0)); then
       echo "$OSH_THEME_GIT_COMMITS_BEHIND_PREFIX$commits$OSH_THEME_GIT_COMMITS_BEHIND_SUFFIX"
     fi
   fi
 }
 
 # Outputs if current branch is ahead of remote
-function git_prompt_ahead() {
-  if [[ -n "$(_omb_prompt_git rev-list origin/$(git_current_branch)..HEAD 2> /dev/null)" ]]; then
+function git_prompt_ahead {
+  if [[ $(_omb_prompt_git rev-list origin/$(git_current_branch)..HEAD 2> /dev/null) ]]; then
     echo "$OSH_THEME_GIT_PROMPT_AHEAD"
   fi
 }
 
 # Outputs if current branch is behind remote
-function git_prompt_behind() {
-  if [[ -n "$(_omb_prompt_git rev-list HEAD..origin/$(git_current_branch) 2> /dev/null)" ]]; then
+function git_prompt_behind {
+  if [[ $(_omb_prompt_git rev-list HEAD..origin/$(git_current_branch) 2> /dev/null) ]]; then
     echo "$OSH_THEME_GIT_PROMPT_BEHIND"
   fi
 }
 
 # Outputs if current branch exists on remote or not
-function git_prompt_remote() {
-  if [[ -n "$(_omb_prompt_git show-ref origin/$(git_current_branch) 2> /dev/null)" ]]; then
+function git_prompt_remote {
+  if [[ $(_omb_prompt_git show-ref origin/$(git_current_branch) 2> /dev/null) ]]; then
     echo "$OSH_THEME_GIT_PROMPT_REMOTE_EXISTS"
   else
     echo "$OSH_THEME_GIT_PROMPT_REMOTE_MISSING"
@@ -126,69 +125,60 @@ function git_prompt_remote() {
 }
 
 # Formats prompt string for current git commit short SHA
-function git_prompt_short_sha() {
+function git_prompt_short_sha {
   local SHA
-  SHA=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) && echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
+  SHA=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) &&
+    echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
 # Formats prompt string for current git commit long SHA
-function git_prompt_long_sha() {
+function git_prompt_long_sha {
   local SHA
-  SHA=$(_omb_prompt_git rev-parse HEAD 2> /dev/null) && echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
+  SHA=$(_omb_prompt_git rev-parse HEAD 2> /dev/null) &&
+    echo "$OSH_THEME_GIT_PROMPT_SHA_BEFORE$SHA$OSH_THEME_GIT_PROMPT_SHA_AFTER"
 }
 
 # Get the status of the working tree
-function git_prompt_status() {
-  local INDEX STATUS
-  INDEX=$(_omb_prompt_git status --porcelain -b 2> /dev/null)
-  STATUS=""
-  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_UNTRACKED$STATUS"
+function git_prompt_status {
+  local INDEX=$(_omb_prompt_git status --porcelain -b 2> /dev/null)
+  local STATUS=
+  if command grep -qE '^\?\? ' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_UNTRACKED$STATUS
   fi
-  if $(echo "$INDEX" | grep '^A  ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_ADDED$STATUS"
-  elif $(echo "$INDEX" | grep '^M  ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_ADDED$STATUS"
+  if command grep -q '^[AM]  ' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_ADDED$STATUS
   fi
-  if $(echo "$INDEX" | grep '^ M ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^AM ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
-  elif $(echo "$INDEX" | grep '^ T ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_MODIFIED$STATUS"
+  if command grep -qE '^[ A]M |^ T ' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_MODIFIED$STATUS
   fi
-  if $(echo "$INDEX" | grep '^R  ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_RENAMED$STATUS"
+  if command grep -q '^R  ' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_RENAMED$STATUS
   fi
-  if $(echo "$INDEX" | grep '^ D ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^D  ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_DELETED$STATUS"
-  elif $(echo "$INDEX" | grep '^AD ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_DELETED$STATUS"
+  if command grep -qE '^[ A]D |D  ' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_DELETED$STATUS
   fi
-  if $(_omb_prompt_git rev-parse --verify refs/stash >/dev/null 2>&1); then
-    STATUS="$OSH_THEME_GIT_PROMPT_STASHED$STATUS"
+  if _omb_prompt_git rev-parse --verify refs/stash &> /dev/null; then
+    STATUS=$OSH_THEME_GIT_PROMPT_STASHED$STATUS
   fi
-  if $(echo "$INDEX" | grep '^UU ' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_UNMERGED$STATUS"
+  if command grep -q '^UU ' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_UNMERGED$STATUS
   fi
-  if $(echo "$INDEX" | grep '^## [^ ]\+ .*ahead' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_AHEAD$STATUS"
+  if command grep -q '^## [^ ]\+ .*ahead' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_AHEAD$STATUS
   fi
-  if $(echo "$INDEX" | grep '^## [^ ]\+ .*behind' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_BEHIND$STATUS"
+  if command grep -q '^## [^ ]\+ .*behind' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_BEHIND$STATUS
   fi
-  if $(echo "$INDEX" | grep '^## [^ ]\+ .*diverged' &> /dev/null); then
-    STATUS="$OSH_THEME_GIT_PROMPT_DIVERGED$STATUS"
+  if command grep -q '^## [^ ]\+ .*diverged' <<< "$INDEX"; then
+    STATUS=$OSH_THEME_GIT_PROMPT_DIVERGED$STATUS
   fi
-  echo $STATUS
+  echo "$STATUS"
 }
 
 # Compares the provided version of git to the version installed and on path
 # Outputs -1, 0, or 1 if the installed version is less than, equal to, or
 # greater than the input version, respectively.
-function git_compare_version() {
+function git_compare_version {
   local INPUT_GIT_VERSION INSTALLED_GIT_VERSION
   _omb_util_split INPUT_GIT_VERSION "$1" '.'
   _omb_util_split INSTALLED_GIT_VERSION "$(_omb_prompt_git --version 2>/dev/null)"
@@ -210,13 +200,13 @@ function git_compare_version() {
 
 # Outputs the name of the current user
 # Usage example: $(git_current_user_name)
-function git_current_user_name() {
+function git_current_user_name {
   _omb_prompt_git config user.name 2>/dev/null
 }
 
 # Outputs the email of the current user
 # Usage example: $(git_current_user_email)
-function git_current_user_email() {
+function git_current_user_email {
   _omb_prompt_git config user.email 2>/dev/null
 }
 

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -3,14 +3,16 @@
 
 _omb_module_require lib:omb-prompt-colors
 
-function git_prompt_info() {
-  local ref
-  if [[ "$(command git config --get oh-my-bash.hide-status 2>/dev/null)" != "1" ]]; then
-    ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
-    echo "$OSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$OSH_THEME_GIT_PROMPT_SUFFIX"
-  fi
-}
+# # Note: The same name of a functionis defined in omb-prompt-base.  We comment
+# # out this function for now.
+# function git_prompt_info() {
+#   local ref
+#   if [[ "$(command git config --get oh-my-bash.hide-status 2>/dev/null)" != "1" ]]; then
+#     ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+#     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
+#     echo "$OSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$OSH_THEME_GIT_PROMPT_SUFFIX"
+#   fi
+# }
 
 # Checks if working tree is dirty
 function parse_git_dirty() {

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -49,13 +49,13 @@ function git_remote_status() {
             git_remote_status="$OSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
         elif [[ $ahead -gt 0 ]] && [[ $behind -eq 0 ]]; then
             git_remote_status="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
-            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$_omb_prompt_reset_color%}"
+            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color"
         elif [[ $behind -gt 0 ]] && [[ $ahead -eq 0 ]]; then
             git_remote_status="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE"
-            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$_omb_prompt_reset_color%}"
+            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
         elif [[ $ahead -gt 0 ]] && [[ $behind -gt 0 ]]; then
             git_remote_status="$OSH_THEME_GIT_PROMPT_DIVERGED_REMOTE"
-            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$_omb_prompt_reset_color%}$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))%{$_omb_prompt_reset_color%}"
+            git_remote_status_detailed="$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))$_omb_prompt_reset_color$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE_COLOR$OSH_THEME_GIT_PROMPT_BEHIND_REMOTE$((behind))$_omb_prompt_reset_color"
         fi
 
         if [[ -n $OSH_THEME_GIT_PROMPT_REMOTE_STATUS_DETAILED ]]; then
@@ -190,16 +190,17 @@ function git_prompt_status() {
 # greater than the input version, respectively.
 function git_compare_version() {
   local INPUT_GIT_VERSION INSTALLED_GIT_VERSION
-  INPUT_GIT_VERSION=(${(s/./)1})
-  INSTALLED_GIT_VERSION=($(_omb_prompt_git --version 2>/dev/null))
-  INSTALLED_GIT_VERSION=(${(s/./)INSTALLED_GIT_VERSION[3]})
+  _omb_util_split INPUT_GIT_VERSION "$1" '.'
+  _omb_util_split INSTALLED_GIT_VERSION "$(_omb_prompt_git --version 2>/dev/null)"
+  _omb_util_split INSTALLED_GIT_VERSION "${INSTALLED_GIT_VERSION[2]}" '.'
 
-  for i in {1..3}; do
-    if [[ $INSTALLED_GIT_VERSION[$i] -gt $INPUT_GIT_VERSION[$i] ]]; then
+  local i
+  for i in {0..2}; do
+    if ((INSTALLED_GIT_VERSION[i] > INPUT_GIT_VERSION[i])); then
       echo 1
       return 0
     fi
-    if [[ $INSTALLED_GIT_VERSION[$i] -lt $INPUT_GIT_VERSION[$i] ]]; then
+    if ((INSTALLED_GIT_VERSION[i] < INPUT_GIT_VERSION[i])); then
       echo -1
       return 0
     fi

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -400,6 +400,14 @@ function _omb_util_glob_expand {
   return 0
 }
 
+function _omb_util_split {
+  local __set=$- IFS=${3:-$' \t\n'}
+  set -f
+  eval -- "$1=(\$2)"
+  [[ $__set == *f* ]] || set +f
+  return 0
+}
+
 function _omb_util_alias {
   case ${OMB_DEFAULT_ALIASES:-enable} in
   (disable) return 0 ;;

--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -87,7 +87,7 @@ function _omb_module_require {
     status=127
   done
 
-  if ((status==0)); then
+  if ((status == 0)); then
     local i
     for i in "${!files[@]}"; do
       local path=${files[i]} module=${modules[i]}
@@ -117,11 +117,11 @@ _omb_module_require_lib "${_omb_init_files[@]}"
 unset -v _omb_init_files
 
 # Figure out the SHORT hostname
-if [[ "$OSTYPE" = darwin* ]]; then
+if [[ $OSTYPE = darwin* ]]; then
   # macOS's $HOST changes with dhcp, etc. Use ComputerName if possible.
-  SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST=${HOST/.*/}
+  SHORT_HOST=$(scutil --get ComputerName 2>/dev/null) || SHORT_HOST=${HOST/.*}
 else
-  SHORT_HOST=${HOST/.*/}
+  SHORT_HOST=${HOST/.*}
 fi
 
 # Load all of the plugins that were defined in ~/.bashrc
@@ -158,13 +158,18 @@ elif [[ $OSH_THEME ]]; then
 fi
 
 if [[ $PROMPT ]]; then
-  export PS1="\["$PROMPT"\]"
+  export PS1='\['$PROMPT'\]'
 fi
 
-if ! _omb_util_command_exists '__git_ps1' ; then
+if ! _omb_util_command_exists '__git_ps1'; then
   source "$OSH/tools/git-prompt.sh"
 fi
 
 # Adding Support for other OSes
-[ -s /usr/bin/gloobus-preview ] && PREVIEW="gloobus-preview" ||
-[ -s /Applications/Preview.app ] && PREVIEW="/Applications/Preview.app" || PREVIEW="less"
+if [[ -s /usr/bin/gloobus-preview ]]; then
+  PREVIEW="gloobus-preview"
+elif [[ -s /Applications/Preview.app ]]; then
+  PREVIEW="/Applications/Preview.app"
+else
+  PREVIEW="less"
+fi

--- a/oh-my-bash.sh
+++ b/oh-my-bash.sh
@@ -51,14 +51,15 @@ fi
 _omb_module_loaded=
 function _omb_module_require {
   local status=0
-  local -a files=()
+  local -a files=() modules=()
   while (($#)); do
     local type=lib name=$1; shift
     [[ $name == *:* ]] && type=${name%%:*} name=${name#*:}
     name=${name%.bash}
     name=${name%.sh}
-    [[ ' '$_omb_module_loaded' ' == *" $type:$name "* ]] && continue
-    _omb_module_loaded="$_omb_module_loaded $type:$name"
+
+    local module=$type:$name
+    [[ ' '$_omb_module_loaded' ' == *" $module "* ]] && continue
 
     local -a locations=()
     case $type in
@@ -77,6 +78,7 @@ function _omb_module_require {
     for path in "${locations[@]}"; do
       if [[ -f $path ]]; then
         files+=("$path")
+        modules+=("$module")
         continue 2
       fi
     done
@@ -86,8 +88,11 @@ function _omb_module_require {
   done
 
   if ((status==0)); then
-    local path
-    for path in "${files[@]}"; do
+    local i
+    for i in "${!files[@]}"; do
+      local path=${files[i]} module=${modules[i]}
+      [[ ' '$_omb_module_loaded' ' == *" $module "* ]] && continue
+      _omb_module_loaded="$_omb_module_loaded $module"
       source "$path" || status=$?
     done
   fi

--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -353,25 +353,25 @@ function prompt_histdt {
 
 
 function git_status_dirty {
-  dirty=$(command git status -s 2> /dev/null | tail -n 1)
+  dirty=$(_omb_prompt_git status -s 2> /dev/null | tail -n 1)
   [[ -n $dirty ]] && echo " ●"
 }
 
 function git_stash_dirty {
-  stash=$(command git stash list 2> /dev/null | tail -n 1)
+  stash=$(_omb_prompt_git stash list 2> /dev/null | tail -n 1)
   [[ -n $stash ]] && echo " ⚑"
 }
 
 # Git: branch/detached head, dirty status
 function prompt_git {
   local ref dirty
-  if command git rev-parse --is-inside-work-tree &>/dev/null; then
+  if _omb_prompt_git rev-parse --is-inside-work-tree &>/dev/null; then
     ZSH_THEME_GIT_PROMPT_DIRTY='±'
     dirty=$(git_status_dirty)
     stash=$(git_stash_dirty)
-    ref=$(command git symbolic-ref HEAD 2> /dev/null) ||
-      ref="➦ $(command git describe --exact-match --tags HEAD 2> /dev/null)" ||
-      ref="➦ $(command git show-ref --head -s --abbrev | head -n1 2> /dev/null)"
+    ref=$(_omb_prompt_git symbolic-ref HEAD 2> /dev/null) ||
+      ref="➦ $(_omb_prompt_git describe --exact-match --tags HEAD 2> /dev/null)" ||
+      ref="➦ $(_omb_prompt_git show-ref --head -s --abbrev | head -n1 2> /dev/null)"
     if [[ -n $dirty ]]; then
       prompt_segment yellow black
     else

--- a/themes/agnoster/agnoster.theme.sh
+++ b/themes/agnoster/agnoster.theme.sh
@@ -263,7 +263,7 @@ function prompt_segment {
     debug "post prompt " $(ansi codes[@])
     PR="$PR$(ansi codes[@]) "
   else
-    debug "no current BG, codes is $codes[@]"
+    debug "no current BG, codes are (${codes[*]})"
     PR="$PR$(ansi codes[@]) "
   fi
   CURRENT_BG=$1
@@ -521,7 +521,7 @@ function prompt_right_segment {
   debug "post prompt " $(ansi_r codes[@])
   PRIGHT="$PRIGHT$(ansi_r codes[@]) "
   # else
-  #     debug "no current BG, codes is $codes[@]"
+  #     debug "no current BG, codes are (${codes[*]})"
   #     PRIGHT="$PRIGHT$(ansi codes[@]) "
   # fi
   CURRENT_RBG=$1

--- a/themes/cooperkid/cooperkid.theme.sh
+++ b/themes/cooperkid/cooperkid.theme.sh
@@ -14,7 +14,7 @@ GIT_SHA_PREFIX="${_omb_prompt_navy}"
 GIT_SHA_SUFFIX="${_omb_prompt_reset_color}"
 
 function git_short_sha() {
-  SHA=$(command git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
+  SHA=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
 }
 
 function _omb_theme_PROMPT_COMMAND() {

--- a/themes/cupcake/cupcake.theme.sh
+++ b/themes/cupcake/cupcake.theme.sh
@@ -63,7 +63,7 @@ function winname {
 
 # Displays the current prompt
 function _omb_theme_PROMPT_COMMAND() {
-  PS1="\n${icon_start}$(_omb_prompt_print_python_venv)${icon_user}${_omb_prompt_bold_brown}\u${_omb_prompt_normal}${icon_host}${_omb_prompt_bold_teal}\h${_omb_prompt_normal}${icon_directory}${_omb_prompt_bold_purple}\W${_omb_prompt_normal}\$([[ -n \$(command git branch 2> /dev/null) ]] && echo \" on ${icon_branch}  \")${_omb_prompt_white}$(scm_prompt_info)${_omb_prompt_normal}\n${icon_end}"
+  PS1="\n${icon_start}$(_omb_prompt_print_python_venv)${icon_user}${_omb_prompt_bold_brown}\u${_omb_prompt_normal}${icon_host}${_omb_prompt_bold_teal}\h${_omb_prompt_normal}${icon_directory}${_omb_prompt_bold_purple}\W${_omb_prompt_normal}\$([[ -n \$(_omb_prompt_git branch 2> /dev/null) ]] && echo \" on ${icon_branch}  \")${_omb_prompt_white}$(scm_prompt_info)${_omb_prompt_normal}\n${icon_end}"
   PS2="${icon_end}"
 }
 

--- a/themes/doubletime/doubletime.theme.sh
+++ b/themes/doubletime/doubletime.theme.sh
@@ -55,7 +55,7 @@ _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND
 
 function git_prompt_status {
   local git_status_output
-  git_status_output=$(command git status 2> /dev/null )
+  git_status_output=$(_omb_prompt_git status 2> /dev/null )
   if [ -n "$(echo $git_status_output | grep 'Changes not staged')" ]; then
     git_status="${_omb_prompt_bold_brown}$(scm_prompt_info) ✗"
   elif [ -n "$(echo $git_status_output | grep 'Changes to be committed')" ]; then

--- a/themes/hawaii50/hawaii50.theme.sh
+++ b/themes/hawaii50/hawaii50.theme.sh
@@ -118,15 +118,15 @@ function virtual_prompt_info() {
 
 # Parse git info
 function git_prompt_info() {
-    if [[ -n $(command git status -s 2> /dev/null |grep -v ^# |grep -v "working directory clean") ]]; then
+    if [[ -n $(_omb_prompt_git status -s 2> /dev/null |grep -v ^# |grep -v "working directory clean") ]]; then
         local state=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
     else
         local state=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
     fi
     local prefix=${GIT_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
     local suffix=${GIT_THEME_PROMPT_SUFFIX:-$SCM_THEME_PROMPT_SUFFIX}
-    local ref=$(command git symbolic-ref HEAD 2> /dev/null) || return
-    local commit_id=$(command git rev-parse HEAD 2>/dev/null) || return
+    local ref=$(_omb_prompt_git symbolic-ref HEAD 2> /dev/null) || return
+    local commit_id=$(_omb_prompt_git rev-parse HEAD 2>/dev/null) || return
 
     echo -e "$prefix${REF_COLOR}${ref#refs/heads/}${DEFAULT_COLOR}:${commit_id:0:$MAX_GIT_HEX_LENGTH}$state$suffix"
 }

--- a/themes/mbriggs/mbriggs.theme.sh
+++ b/themes/mbriggs/mbriggs.theme.sh
@@ -14,7 +14,7 @@ GIT_SHA_PREFIX=" ${_omb_prompt_olive}"
 GIT_SHA_SUFFIX="${_omb_prompt_reset_color}"
 
 function git_short_sha() {
-  SHA=$(command git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
+  SHA=$(_omb_prompt_git rev-parse --short HEAD 2> /dev/null) && echo "$GIT_SHA_PREFIX$SHA$GIT_SHA_SUFFIX"
 }
 
 function _omb_theme_PROMPT_COMMAND() {

--- a/themes/pzq/pzq.theme.sh
+++ b/themes/pzq/pzq.theme.sh
@@ -71,13 +71,13 @@ function prompt_git {
   local branchName=''
 
   # Check if the current directory is in a Git repository.
-  if git rev-parse --is-inside-work-tree &>/dev/null; then
+  if _omb_prompt_git rev-parse --is-inside-work-tree &>/dev/null; then
     # Get the short symbolic ref.
     # If HEAD isn’t a symbolic ref, get the short SHA for the latest commit
     # Otherwise, just give up.
     branchName=$(
-      git symbolic-ref --quiet --short HEAD 2> /dev/null ||
-        git rev-parse --short HEAD 2> /dev/null ||
+      _omb_prompt_git symbolic-ref --quiet --short HEAD 2> /dev/null ||
+        _omb_prompt_git rev-parse --short HEAD 2> /dev/null ||
         echo '(unknown)');
 
     echo "${D_GIT_DEFAULT_COLOR}on ${D_GIT_BRANCH_COLOR}${branchName} "

--- a/themes/rana/rana.theme.sh
+++ b/themes/rana/rana.theme.sh
@@ -116,31 +116,31 @@ function prompt_git {
   local branchName=''
 
   # Check if the current directory is in a Git repository.
-  if command git rev-parse --is-inside-work-tree &>/dev/null; then
+  if _omb_prompt_git rev-parse --is-inside-work-tree &>/dev/null; then
 
     # check if the current directory is in .git before running git checks
-    if [[ $(command git rev-parse --is-inside-git-dir 2> /dev/null) == false ]]; then
+    if [[ $(_omb_prompt_git rev-parse --is-inside-git-dir 2> /dev/null) == false ]]; then
 
       # Ensure the index is up to date.
-      command git update-index --really-refresh -q &>/dev/null
+      _omb_prompt_git update-index --really-refresh -q &>/dev/null
 
       # Check for uncommitted changes in the index.
-      if ! command git diff --quiet --ignore-submodules --cached; then
+      if ! _omb_prompt_git diff --quiet --ignore-submodules --cached; then
         s+='+'
       fi
 
       # Check for unstaged changes.
-      if ! command git diff-files --quiet --ignore-submodules --; then
+      if ! _omb_prompt_git diff-files --quiet --ignore-submodules --; then
         s+='!'
       fi
 
       # Check for untracked files.
-      if [[ $(command git ls-files --others --exclude-standard) ]]; then
+      if [[ $(_omb_prompt_git ls-files --others --exclude-standard) ]]; then
         s+='?'
       fi
 
       # Check for stashed files.
-      if command git rev-parse --verify refs/stash &>/dev/null; then
+      if _omb_prompt_git rev-parse --verify refs/stash &>/dev/null; then
         s+='$'
       fi
 
@@ -150,8 +150,8 @@ function prompt_git {
     # If HEAD isn’t a symbolic ref, get the short SHA for the latest commit
     # Otherwise, just give up.
     branchName=$(
-      command git symbolic-ref --quiet --short HEAD 2> /dev/null ||
-        command git rev-parse --short HEAD 2> /dev/null ||
+      _omb_prompt_git symbolic-ref --quiet --short HEAD 2> /dev/null ||
+        _omb_prompt_git rev-parse --short HEAD 2> /dev/null ||
         echo '(unknown)')
 
     [[ $s ]] && s=" [$s]"

--- a/themes/sexy/sexy.theme.sh
+++ b/themes/sexy/sexy.theme.sh
@@ -27,16 +27,16 @@ OMB_PROMPT_CONDAENV_USE_BASENAME=true
 OMB_PROMPT_SHOW_PYTHON_VENV=${OMB_PROMPT_SHOW_PYTHON_VENV:=false}
 
 function parse_git_dirty {
-  [[ $(command git status 2> /dev/null | tail -n1 | cut -c 1-17) != "nothing to commit" ]] && echo "*"
+  [[ $(_omb_prompt_git status 2> /dev/null | tail -n1 | cut -c 1-17) != "nothing to commit" ]] && echo "*"
 }
 function parse_git_branch {
-  command git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
+  _omb_prompt_git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
 }
 
 function _omb_theme_PROMPT_COMMAND() {
   local python_venv
   _omb_prompt_get_python_venv
-  PS1="$python_venv${MAGENTA}\u ${WHITE}at ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}\$([[ -n \$(command git branch 2> /dev/null) ]] && echo \" on \")${PURPLE}\$(parse_git_branch)${WHITE}\n\$ ${RESET}"
+  PS1="$python_venv${MAGENTA}\u ${WHITE}at ${ORANGE}\h ${WHITE}in ${GREEN}\w${WHITE}\$([[ -n \$(_omb_prompt_git branch 2> /dev/null) ]] && echo \" on \")${PURPLE}\$(parse_git_branch)${WHITE}\n\$ ${RESET}"
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND

--- a/themes/vscode/vscode.theme.sh
+++ b/themes/vscode/vscode.theme.sh
@@ -20,11 +20,11 @@ function _omb_theme_vscode_initialize {
         && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
-        if [ "$(git config --get codespaces-theme.hide-status 2>/dev/null)" != 1 ]; then \
-            export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
+        if [ "$(_omb_prompt_git config --get codespaces-theme.hide-status 2>/dev/null)" != 1 ]; then \
+            export BRANCH=$(_omb_prompt_git symbolic-ref --short HEAD 2>/dev/null || _omb_prompt_git rev-parse --short HEAD 2>/dev/null); \
             if [ "${BRANCH}" != "" ]; then \
                 echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
-                && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
+                && if _omb_prompt_git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                         echo -n " \[\033[1;33m\]✗"; \
                 fi \
                 && echo -n "\[\033[0;36m\]) "; \


### PR DESCRIPTION
This also includes refactoring.

- 779d5fada73e401357a63d727bb7291e42bad495 The main fix for the uses of Zsh constructs.
- e2a9fae9274abde0be6ae8889c44dc4f22ae9cd0 This is to avoid a conflict with the same name of a function defined in another file.
- 960ac2596f68145f48feb0b035d9a226da52ddac This makes the invocation of `command git` for prompts and completions indirect through the function `_omb_prompt_git`. This will be a base for #428 and #173. As far as we directly call `command git`, we need to specify the command modifications for timeouts and git settings for every invocation of `command git`, which is not useful.
- ad07989f4abfa3c6c5fc311e917bf5f78de2470d A utility function to split a string safely.
- a4e0ca1ec9f46f07480a4c6361973c6ff1918fdd and 4d541cf1085dcfb0be33f4724e62c3e7b4e2ff6c Style changes.
