### PR TITLE
ci: Use `setup-go` to install Go v1.20

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
           format: "json"
       - name: Check out code.
         uses: actions/checkout@v2
-      - uses: 'actions/setup-go'
+      - uses: 'actions/setup-go@v4'
         with:
           go-version: '1.20'
       - name: "Check EditorConfig Lint"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,11 +17,14 @@ jobs:
           format: "json"
       - name: Check out code.
         uses: actions/checkout@v2
+      - uses: 'actions/setup-go'
+        with:
+          go-version: '1.20'
       - name: "Check EditorConfig Lint"
         env:
           EDITORCONFIG_FLAGS: '-disable-indent-size -disable-indentation'
         run: |
-          sudo apt install -y jq golang
+          sudo apt install -y jq
           go install 'github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest'
           readarray -t changed_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.added_modified }}')"
           ~/go/bin/editorconfig-checker ${{ env.EDITORCONFIG_FLAGS }} ${changed_files[@]}


### PR DESCRIPTION
This uses `actions/setup-go` to install Go. The minimum required version is now 1.20 as per [this](https://github.com/editorconfig/editorconfig-core-go/commit/73c37c49c298ff5a605f2a07228f3f99acf3d2d8) commit in [editorconfig-core-go](https://github.com/editorconfig/editorconfig-core-go).

Fixes an issue mentioned in #484