### PR TITLE
lib/history: remove redundant export for HISTIGNORE

### DIFF
--- a/lib/history.sh
+++ b/lib/history.sh
@@ -36,7 +36,7 @@ export HISTFILESIZE=
 HISTCONTROL="erasedups:ignoreboth"
 
 # Don't record some commands
-export HISTIGNORE="exit:ls:bg:fg:history:clear"
+HISTIGNORE="exit:ls:bg:fg:history:clear"
 
 # Enable incremental history search with up/down arrows (also Readline goodness)
 # Learn more about this here: https://codeinthehole.com/tips/the-most-important-command-line-tip-incremental-history-searching-with-inputrc/


### PR DESCRIPTION
There does not seem to be a specific reason that we export HISTIGNORE as mentioned in https://github.com/ohmybash/oh-my-bash/discussions/500#discussioncomment-7676355.  These lines were introduced in commit 53fb8037 but only HISTIGNORE had `export`.

In this PR, I try to remove the redundant `export` from the definition of `HISTIGNORE`. I'll wait for a while. If anyone has a reason to export HISTIGNORE, please let me know in this PR.