### PR TITLE
lib/shopt: remove nocasematch

### DIFF
--- a/lib/shopt.sh
+++ b/lib/shopt.sh
@@ -25,10 +25,8 @@ shopt -s globstar 2> /dev/null
 # (used in case, [[]], word expansions and command completions)
 if [[ ${OMB_CASE_SENSITIVE:-${CASE_SENSITIVE:-}} == true ]]; then
    shopt -u nocaseglob
-   shopt -u nocasematch
 else
    shopt -s nocaseglob
-   shopt -s nocasematch
 fi
 
 ## SMARTER TAB-COMPLETION (Readline bindings) ##


### PR DESCRIPTION
The setting `shopt -s nocasematch` affects every pattern matching in Bash including the case statement, `[[ str == pat ]]` matching, `${var/pat/rep}`, and `${var#pat}`.  Since the affected range is too large, this potentially breaks the existing functions.  I think this setting `shopt -s nocasematch` should be enabled locally when it is specifically needed rather than enabling it globally.

----

These settings seem to have been introduced in #399 where the proper support for `CASE_SENSITIVE` was attempted. Before this PR, only `nocaseglob` has been specified in OMB.

@jjmcdn Could you take a look at this PR? Since you have introduced `nocasematch`, I need to check the background and motivations of making `nocasematch` controlled by `CASE_SENSITIVE`. As I've described above, `nocasematch` (in the latest Bash version) affects all the matching behavior using glob to be case insensitive by default. However, this caused an issue at https://github.com/akinomyoga/ble.sh/discussions/376. The problem is that unexpected replacement happens with `${var/pat/str}` when the pattern `pat` matches the text content of `$var` in a case-insensitive way. The affected range also includes the `case` statement. For example,

```bash
(shopt -s nocasematch; case A in a) echo small ;; A) echo capital ;; esac)
```

will output `small` instead of `capital`. Also the string comparison by `[[ lhs == rhs ]]` is also affected by `nocasematch`.

I'm now thinking about the possibility of excluding `nocasematch` from the list of settings controlled by `CASE_SENSITIVE` (as in this PR). The setting `nocasematch` doesn't seem to be the one that should be turned on globally since the affected range is too large.
