### PR TITLE
lib/nvm: update autoloader to keep up with the upstream

### DIFF
--- a/plugins/nvm/nvm.plugin.sh
+++ b/plugins/nvm/nvm.plugin.sh
@@ -79,17 +79,17 @@ if _omb_util_command_exists nvm && [[ ${OMB_PLUGIN_NVM_AUTO_USE-} == true ]]; th
       local nvm_version
       nvm_version=$(< "$nvm_path"/.nvmrc)
 
-      # Add the `v` suffix if it does not exists in the .nvmrc file
-      if [[ $nvm_version != v* ]]; then
-        nvm_version=v$nvm_version
-      fi
+      local locally_resolved_nvm_version
+      # `nvm ls` will check all locally-available versions.  If there are
+      # multiple matching versions, take the latest one.  Remove the `->` and
+      # `*` characters and spaces.  `locally_resolved_nvm_version` will be
+      # `N/A` if no local versions are found.
+      locally_resolved_nvm_version=$(nvm ls --no-colors $(<"./.nvmrc") | sed -n '${s/->//g;s/[*[:space:]]//g;p;}')
 
       # If it is not already installed, install it
-      if nvm ls "$nvm_version" | grep -qx '[[:space:]]*N/A[[:space:]]*'; then
+      if [[ $locally_resolved_nvm_version == N/A ]]; then
         nvm install "$nvm_version"
-      fi
-
-      if [[ $(nvm current) != "$nvm_version" ]]; then
+      elif [[ $(nvm current) != "$locally_resolved_nvm_version" ]]; then
         nvm use "$nvm_version"
       fi
     fi


### PR DESCRIPTION
Fixes #504

This PR applies the changes introduced in https://github.com/nvm-sh/nvm/pull/2017. I skip the upstream changes introduced in https://github.com/nvm-sh/nvm/pull/2313 and in https://github.com/nvm-sh/nvm/pull/3082.

@ffd114 Could you check this branch (`nvm-update` branch at `akinomyoga/oh-my-bash`)?