### PR TITLE
Error correction in the powerline-icon theme

### DIFF
--- a/themes/THEMES.md
+++ b/themes/THEMES.md
@@ -176,6 +176,10 @@
 
 [![](powerline/powerline-dark.png)](powerline/powerline-dark.png)
 
+## `powerline-icon`
+
+[![](powerline-icon/powerline-icon-dark.png)](powerline-icon/powerline-icon-dark.png)
+
 ## `powerline-light`
 
 [![](powerline-light/powerline-light.png)](powerline-light/powerline-light.png)

--- a/themes/powerline-icon/powerline-icon.base.sh
+++ b/themes/powerline-icon/powerline-icon.base.sh
@@ -41,3 +41,32 @@ function __powerline_last_status_prompt {
     echo "✅|${LAST_STATUS_THEME_PROMPT_COLOR_SUCCESS}"
   fi
 }
+
+function __powerline_prompt_command {
+  local last_status="$?" ## always the first
+  local separator_char="${POWERLINE_PROMPT_CHAR}"
+
+  LEFT_PROMPT=""
+  SEGMENTS_AT_LEFT=0
+  LAST_SEGMENT_COLOR=""
+
+  # The IFS (internal field seperator) may have been changed outside to not contain
+  # the space character ' ' whence we need to make sure that the space separated list
+  # stored in POWERLINE_PROMPT is converted into an array correctly.
+  IFS=' ' read -r -a POWERLINE_PROMPT_ARRAY <<< "${POWERLINE_PROMPT}"
+
+  ## left prompt ##
+  for segment in ${POWERLINE_PROMPT_ARRAY[@]}; do
+    local info="$(__powerline_${segment}_prompt)"
+    [[ -n "${info}" ]] && __powerline_left_segment "${info}"
+  done
+  __powerline_left_segment $(__powerline_last_status_prompt ${last_status})
+  [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(set_color ${LAST_SEGMENT_COLOR} -)${separator_char}${_omb_prompt_normal}"
+
+  PS1="${LEFT_PROMPT} "
+
+  ## cleanup ##
+  unset LAST_SEGMENT_COLOR \
+        LEFT_PROMPT \
+        SEGMENTS_AT_LEFT
+}

--- a/themes/powerline-icon/powerline-icon.base.sh
+++ b/themes/powerline-icon/powerline-icon.base.sh
@@ -41,32 +41,3 @@ function __powerline_last_status_prompt {
     echo "✅|${LAST_STATUS_THEME_PROMPT_COLOR_SUCCESS}"
   fi
 }
-
-function __powerline_prompt_command {
-  local last_status="$?" ## always the first
-  local separator_char="${POWERLINE_PROMPT_CHAR}"
-
-  LEFT_PROMPT=""
-  SEGMENTS_AT_LEFT=0
-  LAST_SEGMENT_COLOR=""
-
-  # The IFS (internal field seperator) may have been changed outside to not contain
-  # the space character ' ' whence we need to make sure that the space separated list
-  # stored in POWERLINE_PROMPT is converted into an array correctly.
-  IFS=' ' read -r -a POWERLINE_PROMPT_ARRAY <<< "${POWERLINE_PROMPT}"
-
-  ## left prompt ##
-  for segment in ${POWERLINE_PROMPT_ARRAY[@]}; do
-    local info="$(__powerline_${segment}_prompt)"
-    [[ -n "${info}" ]] && __powerline_left_segment "${info}"
-  done
-  __powerline_left_segment $(__powerline_last_status_prompt ${last_status})
-  [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(set_color ${LAST_SEGMENT_COLOR} -)${separator_char}${_omb_prompt_normal}"
-
-  PS1="${LEFT_PROMPT} "
-
-  ## cleanup ##
-  unset LAST_SEGMENT_COLOR \
-        LEFT_PROMPT \
-        SEGMENTS_AT_LEFT
-}

--- a/themes/powerline/powerline.base.sh
+++ b/themes/powerline/powerline.base.sh
@@ -194,7 +194,7 @@ function __powerline_prompt_command {
   done
 
   ## info status prompt ##
-  info="$(__powerline_last_status_prompt ${last_status})"
+  local info="$(__powerline_last_status_prompt ${last_status})"
   [[ -n "${info}" ]] && __powerline_left_segment "${info}"
 
   [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(set_color ${LAST_SEGMENT_COLOR} -)${separator_char}${_omb_prompt_normal}"

--- a/themes/powerline/powerline.base.sh
+++ b/themes/powerline/powerline.base.sh
@@ -188,7 +188,7 @@ function __powerline_prompt_command {
   IFS=' ' read -r -a POWERLINE_PROMPT_ARRAY <<< "${POWERLINE_PROMPT}"
 
   ## left prompt ##
-  for segment in ${POWERLINE_PROMPT_ARRAY[@]};
+  for segment in ${POWERLINE_PROMPT_ARRAY[@]}; do
     local info="$(__powerline_${segment}_prompt)"
     [[ -n "${info}" ]] && __powerline_left_segment "${info}"
   done

--- a/themes/powerline/powerline.base.sh
+++ b/themes/powerline/powerline.base.sh
@@ -188,11 +188,15 @@ function __powerline_prompt_command {
   IFS=' ' read -r -a POWERLINE_PROMPT_ARRAY <<< "${POWERLINE_PROMPT}"
 
   ## left prompt ##
-  for segment in ${POWERLINE_PROMPT_ARRAY[@]}; do
+  for segment in ${POWERLINE_PROMPT_ARRAY[@]};
     local info="$(__powerline_${segment}_prompt)"
     [[ -n "${info}" ]] && __powerline_left_segment "${info}"
   done
-  [[ "${last_status}" -ne 0 ]] && __powerline_left_segment $(__powerline_last_status_prompt ${last_status})
+
+  ## info status prompt ##
+  info="$(__powerline_last_status_prompt ${last_status})"
+  [[ -n "${info}" ]] && __powerline_left_segment "${info}"
+
   [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(set_color ${LAST_SEGMENT_COLOR} -)${separator_char}${_omb_prompt_normal}"
 
   PS1="${LEFT_PROMPT} "


### PR DESCRIPTION
Fixed Bugs: 
- An error in one of the powerline functions has been corrected, which was preventing the display of the icon for a successfully executed command.