### PR TITLE
feat: add support for ssh completion using files in .ssh/config.d too

### DIFF
--- a/completions/ssh.completion.sh
+++ b/completions/ssh.completion.sh
@@ -5,7 +5,7 @@ _omb_module_require lib:omb-completion
 
 function _omb_completion_ssh {
   local cur
-  local file_in_config_d
+  local additional_include_defined_file
   _omb_completion_reassemble_breaks :
 
   if [[ $cur == *@*  ]] ; then
@@ -19,12 +19,11 @@ function _omb_completion_ssh {
     COMPREPLY=($(compgen -W "$(grep ^Host "$HOME/.ssh/config" | awk '{for (i=2; i<=NF; i++) print $i}' )" "${options[@]}"))
   fi
 
-  # parse all defined hosts from .ssh/config.d/*
-  if [[ -d $HOME/.ssh/config.d ]]; then
-    for file_in_config_d in "$HOME/.ssh/config.d/"* ;do
-      [[ -s "$file_in_config_d" ]] &&COMPREPLY+=($(compgen -W "$(grep ^Host "$file_in_config_d" | awk '{for (i=2; i<=NF; i++) print $i}' )" "${options[@]}"))
-    done
-  fi
+  # check if .ssh/config contains Include options
+  for additional_include_defined_file in $(awk -F' ' '/^Înclude/{print $2}' 2>/dev/null) ;do
+    # parse all defined hosts from that file
+    [[ -s "$additional_include_defined_file" ]] &&COMPREPLY+=($(compgen -W "$(grep ^Host "$additional_include_defined_file" | awk '{for (i=2; i<=NF; i++) print $i}' )" "${options[@]}"))
+  done
 
   # parse all hosts found in .ssh/known_hosts
   if [[ -r $HOME/.ssh/known_hosts ]]; then

--- a/completions/ssh.completion.sh
+++ b/completions/ssh.completion.sh
@@ -5,6 +5,7 @@ _omb_module_require lib:omb-completion
 
 function _omb_completion_ssh {
   local cur
+  local file_in_config_d
   _omb_completion_reassemble_breaks :
 
   if [[ $cur == *@*  ]] ; then
@@ -16,6 +17,13 @@ function _omb_completion_ssh {
   # parse all defined hosts from .ssh/config
   if [[ -r $HOME/.ssh/config ]]; then
     COMPREPLY=($(compgen -W "$(grep ^Host "$HOME/.ssh/config" | awk '{for (i=2; i<=NF; i++) print $i}' )" "${options[@]}"))
+  fi
+
+  # parse all defined hosts from .ssh/config.d/*
+  if [[ -d $HOME/.ssh/config.d ]]; then
+    for file_in_config_d in "$HOME/.ssh/config.d/"* ;do
+      [[ -s "$file_in_config_d" ]] &&COMPREPLY+=($(compgen -W "$(grep ^Host "$file_in_config_d" | awk '{for (i=2; i<=NF; i++) print $i}' )" "${options[@]}"))
+    done
   fi
 
   # parse all hosts found in .ssh/known_hosts

--- a/completions/ssh.completion.sh
+++ b/completions/ssh.completion.sh
@@ -7,10 +7,11 @@ function _omb_completion_ssh {
   local cur
   _omb_completion_reassemble_breaks :
 
+  local -a options
   if [[ $cur == *@*  ]] ; then
-    local -a options=(-P "${cur%%@*}@" -- "${cur#*@}")
+    options=(-P "${cur%%@*}@" -- "${cur#*@}")
   else
-    local -a options=(-- "$cur")
+    options=(-- "$cur")
   fi
 
   local IFS=$'\n'
@@ -34,7 +35,7 @@ function _omb_completion_ssh {
     local include_file
     for include_file in "${include_files[@]}";do
       # parse all defined hosts from that file
-      [[ -s "$include_file" ]] && config_files+=("$include_file")
+      [[ -s $include_file ]] && config_files+=("$include_file")
     done
 
     COMPREPLY+=($(compgen -W "$(awk '/^Host/ {for (i=2; i<=NF; i++) print $i}' "${config_files[@]}")" "${options[@]}"))

--- a/completions/ssh.completion.sh
+++ b/completions/ssh.completion.sh
@@ -16,12 +16,12 @@ function _omb_completion_ssh {
   local IFS=$'\n'
 
   # parse all defined hosts from .ssh/config
-  if [[ -r $HOME/.ssh/config ]]; then
-    local -a config_files=("$HOME/.ssh/config")
+  if [[ -r ~/.ssh/config ]]; then
+    local -a config_files=(~/.ssh/config)
 
     # check if .ssh/config contains Include options
     local -a include_patterns
-    _omb_util_split include_patterns "$(awk -F' ' '/^Include/{print $2}' "$HOME/.ssh/config" 2>/dev/null)" $'\n'
+    _omb_util_split include_patterns "$(awk -F' ' '/^Include/{print $2}' ~/.ssh/config 2>/dev/null)" $'\n'
     local i
     for i in "${!include_patterns[@]}"; do
       # relative or absolute path, if relative transforms to absolute
@@ -41,9 +41,9 @@ function _omb_completion_ssh {
   fi
 
   # parse all hosts found in .ssh/known_hosts
-  if [[ -r $HOME/.ssh/known_hosts ]]; then
-    if grep -v -q -e '^ ssh-rsa' "$HOME/.ssh/known_hosts" ; then
-      COMPREPLY+=($(compgen -W "$( awk '{print $1}' "$HOME/.ssh/known_hosts" | grep -v ^\| | cut -d, -f 1 | sed -e 's/\[//g' | sed -e 's/\]//g' | cut -d: -f1 | grep -v ssh-rsa)" "${options[@]}"))
+  if [[ -r ~/.ssh/known_hosts ]]; then
+    if grep -v -q -e '^ ssh-rsa' ~/.ssh/known_hosts; then
+      COMPREPLY+=($(compgen -W "$( awk '{print $1}' ~/.ssh/known_hosts | grep -v ^\| | cut -d, -f 1 | sed -e 's/\[//g' | sed -e 's/\]//g' | cut -d: -f1 | grep -v ssh-rsa)" "${options[@]}"))
     fi
   fi
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -366,6 +366,13 @@ function _omb_util_add_prompt_command {
 }
 
 ## @fn _omb_util_split array str [sep]
+##   Split STR with SEP in a safe way and store the result in ARRAY.
+##   @param[out] array
+##     The name of an array variable to which the split result is stored.
+##   @param[in] str
+##     The string to split
+##   @param[in,opt]
+##     The set of separator characters.  The default is ' <tab><newline>'.
 function _omb_util_split {
   local __set=$- IFS=${3:-$' \t\n'}
   set -f
@@ -374,6 +381,13 @@ function _omb_util_split {
   return 0
 }
 
+## @fn _omb_util_glob_expand array glob
+##   Perform the pathname expansion of a glob pattern GLOB in a safe way and
+##   store the filenames in ARRAY.
+##   @param[out] array
+##     The name of an array variable to which the filenames are stored.
+##   @param[in] glob
+##     The glob pattern that is attempted to match filenames
 function _omb_util_glob_expand {
   local __set=$- __shopt __gignore=$GLOBIGNORE
   _omb_util_get_shopt failglob nullglob extglob

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -414,14 +414,6 @@ function _omb_util_glob_expand {
   return 0
 }
 
-function _omb_util_split {
-  local __set=$- IFS=${3:-$' \t\n'}
-  set -f
-  eval -- "$1=(\$2)"
-  [[ $__set == *f* ]] || set +f
-  return 0
-}
-
 function _omb_util_alias {
   case ${OMB_DEFAULT_ALIASES:-enable} in
   (disable) return 0 ;;


### PR DESCRIPTION
From 7.3p1 and up, there is an Include keyword, which allows you to include additional configuration files.  

>Include  
Include the specified configuration file(s).  Multiple pathnames may be specified and each pathname may contain glob(3) wildcards and, for user configurations, shell-like “~” references to user home directories.  Files without absolute paths are assumed to be in ~/.ssh if included in a user configuration file or /etc/ssh if included from the system configuration file.  Include directive may appear inside a Match or Host block to perform conditional inclusion.
Source: [ssh_config(5)](http://man7.org/linux/man-pages/man5/ssh_config.5.html).

So if you have `Include config.d/*` in your `~/.ssh/config` file, this pull request allows files put in `~/.ssh/config.d/` to be also parsed for the `Host` keyword to use completion when calling ssh command (in addition to the default `~/.ssh/config`)   

Why would you want to do that: It's easier to maintain lists of hosts in dedicated files (e.g. separate private-home-lan, company1-project1, company2-project3, etc...)  