### PR TITLE
Resolve VIRTUAL_ENV with double-quotes

### DIFF
--- a/themes/mairan/mairan.theme.sh
+++ b/themes/mairan/mairan.theme.sh
@@ -110,7 +110,7 @@ function _omb_theme_PROMPT_COMMAND {
 
     if [ -n "$VIRTUAL_ENV" ]
     then
-        ve=`basename $VIRTUAL_ENV`;
+        ve=`basename "$VIRTUAL_ENV"`;
     fi
 
     # nice prompt

--- a/themes/zork/zork.theme.sh
+++ b/themes/zork/zork.theme.sh
@@ -77,7 +77,7 @@ function _omb_theme_PROMPT_COMMAND {
 
     if [ -n "$VIRTUAL_ENV" ]
     then
-        ve=`basename $VIRTUAL_ENV`;
+        ve=`basename "$VIRTUAL_ENV"`;
     fi
 
     # nice prompt


### PR DESCRIPTION
Without double-quotes, paths with spaces are not resolved correctly and venv name is not displayed correctly.

Before: 
```
└─▪ echo $VIRTUAL_ENV
~/Documents/Path with spaces/env
basename: extra operand ‘spaces/env’
Try 'basename --help' for more information.
┌─()[name][os][±][( main ?:3 ⊘ )][~<Path redacted>]
```

But with this small change: 

```
┌─(env)[name][os][±][( main ?:3 ⊘ )][~<Path redacted>]
└─▪
```

Edit: I'm not super familiar with Bash, but I'd recommend a quick once-over to make sure this issue doesn't appear in other places for zork. I only really discoverd this because of novice-level Bash knowledge and ChatGPT xd. 