### PR TITLE
add Wiki "Themes" page updater script

### DIFF
--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -28,10 +28,10 @@
 
 # first process current env vars, with some sensible default fallback values...
 
-SCRIPT_WIKI_PATH=${OMB_WIKI_PATH:-../oh-my-bash.wiki}
-SCRIPT_WIKI_THEMES_FILE=${OMB_WIKI_THEMES_FILE:-Themes.md}
-SCRIPT_WIKI_THEMES_START_MARKER=${OMB_WIKI_THEMES_START_MARKER:-'<!-- THEME_GEN_START_MARKER -->'}
-SCRIPT_WIKI_THEMES_END_MARKER=${OMB_WIKI_THEMES_END_MARKER:-'<!-- THEME_GEN_END_MARKER -->'}
+OMB_WIKI_PATH=${OMB_WIKI_PATH:-../oh-my-bash.wiki}
+OMB_WIKI_THEMES_FILE=${OMB_WIKI_THEMES_FILE:-Themes.md}
+OMB_WIKI_THEMES_START_MARKER=${OMB_WIKI_THEMES_START_MARKER:-'<!-- OMB_WIKI_THEMES_START_MARKER -->'}
+OMB_WIKI_THEMES_END_MARKER=${OMB_WIKI_THEMES_END_MARKER:-'<!-- OMB_WIKI_THEMES_END_MARKER -->'}
 
 # then process any cli args, if provided...
 
@@ -44,22 +44,22 @@ while (($#)); do
   case $1 in
   -p | --wiki-path)
     # echo "Processing 'wiki-path' option. Input argument is '$2'"
-    SCRIPT_WIKI_PATH=$2
+    OMB_WIKI_PATH=$2
     shift 2
     ;;
   -f | --themes-file)
     # echo "Processing 'themes-file' option. Input argument is '$2'"
-    SCRIPT_WIKI_THEMES_FILE=$2
+    OMB_WIKI_THEMES_FILE=$2
     shift 2
     ;;
   -s | --start-marker)
     # echo "Processing 'start-marker' option. Input argument is '$2'"
-    SCRIPT_WIKI_THEMES_START_MARKER=$2
+    OMB_WIKI_THEMES_START_MARKER=$2
     shift 2
     ;;
   -e | --end-marker)
     # echo "Processing 'end-marker' option. Input argument is '$2'"
-    SCRIPT_WIKI_THEMES_END_MARKER=$2
+    OMB_WIKI_THEMES_END_MARKER=$2
     shift 2
     ;;
   --)
@@ -70,30 +70,30 @@ while (($#)); do
 done
 
 # debug: this will either be adapted for the final script, or removed entirely..
-printf '%s\n' "current SCRIPT_WIKI_PATH: $SCRIPT_WIKI_PATH"
-printf '%s\n' "current SCRIPT_WIKI_THEMES_FILE: $SCRIPT_WIKI_THEMES_FILE"
-printf '%s\n' "current SCRIPT_WIKI_THEMES_START_MARKER: $SCRIPT_WIKI_THEMES_START_MARKER"
-printf '%s\n' "current SCRIPT_WIKI_THEMES_END_MARKER: $SCRIPT_WIKI_THEMES_END_MARKER"
+printf '%s\n' "current OMB_WIKI_PATH: $OMB_WIKI_PATH"
+printf '%s\n' "current OMB_WIKI_THEMES_FILE: $OMB_WIKI_THEMES_FILE"
+printf '%s\n' "current OMB_WIKI_THEMES_START_MARKER: $OMB_WIKI_THEMES_START_MARKER"
+printf '%s\n' "current OMB_WIKI_THEMES_END_MARKER: $OMB_WIKI_THEMES_END_MARKER"
 
 # verify that the OMB Wiki project exists...
-if [[ ! -d $SCRIPT_WIKI_PATH ]]; then
-  printf '%s\n' "ERROR: Wiki project path '$SCRIPT_WIKI_PATH' does not exist."
+if [[ ! -d $OMB_WIKI_PATH ]]; then
+  printf '%s\n' "ERROR: Wiki project path '$OMB_WIKI_PATH' does not exist."
   exit 1
 fi
 
 # verify that the OMB Wiki contains the expected themes file...
-if [[ ! -f $SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE ]]; then
-  printf '%s\n' "ERROR: Wiki project has no themes file called '$SCRIPT_WIKI_THEMES_FILE'."
+if [[ ! -f $OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE ]]; then
+  printf '%s\n' "ERROR: Wiki project has no themes file called '$OMB_WIKI_THEMES_FILE'."
   exit 1
 fi
 
 # verify that the OMB Wiki contains the expected start and end markers...
-if ! grep -q "$SCRIPT_WIKI_THEMES_START_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"; then
-  printf '%s\n' "ERROR: Wiki themes file does not contain start marker '$SCRIPT_WIKI_THEMES_START_MARKER'."
+if ! grep -q "$OMB_WIKI_THEMES_START_MARKER" "$OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE"; then
+  printf '%s\n' "ERROR: Wiki themes file does not contain start marker '$OMB_WIKI_THEMES_START_MARKER'."
   exit 1
 fi
-if ! grep -q "$SCRIPT_WIKI_THEMES_END_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"; then
-  printf '%s\n' "ERROR: Wiki themes file does not contain end marker '$SCRIPT_WIKI_THEMES_END_MARKER'."
+if ! grep -q "$OMB_WIKI_THEMES_END_MARKER" "$OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE"; then
+  printf '%s\n' "ERROR: Wiki themes file does not contain end marker '$OMB_WIKI_THEMES_END_MARKER'."
   exit 1
 fi
 
@@ -103,7 +103,7 @@ fi
 theme_list=$(find "./themes" -mindepth 1 -maxdepth 1 -type d -print | sort | xargs -n1 basename)
 
 # prepare a variable to hold generated content, starting with with the "start" marker for next run...
-markdown_text="$SCRIPT_WIKI_THEMES_START_MARKER\n\n"
+markdown_text="$OMB_WIKI_THEMES_START_MARKER\n\n"
 
 # now we can loop through the list and find all images in each theme directory...
 for theme in $theme_list; do
@@ -132,8 +132,8 @@ for theme in $theme_list; do
 done
 
 # inject the "end" marker for next run...
-markdown_text=$markdown_text$SCRIPT_WIKI_THEMES_END_MARKER
+markdown_text=$markdown_text$OMB_WIKI_THEMES_END_MARKER
 
 # now we can update the OMB Wiki "Themes" page directly...
-sed -i "/$SCRIPT_WIKI_THEMES_START_MARKER/,/$SCRIPT_WIKI_THEMES_END_MARKER/c\\
-$markdown_text" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"
+sed -i "/$OMB_WIKI_THEMES_START_MARKER/,/$OMB_WIKI_THEMES_END_MARKER/c\\
+$markdown_text" "$OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE"

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
-# this script aims to simplify the process of updating the theme examples page in the GitHub Wiki.
+# this script aims to simplify the process of updating the theme examples page
+# in the GitHub Wiki.
 #
-# it is built with the assumption that the relevant wiki is cloned with Git alongside this repo, but with the understanding that this may not always be true.
+# it is built with the assumption that the relevant wiki is cloned with Git
+# alongside this repo, but with the understanding that this may not always be
+# true.
 #
-# it also assumes the associated `Themes.md` file exists at the root of the wiki, and contains the relevant "start" and "end" markers for a safe space to re-render the theme examples.
+# it also assumes the associated `Themes.md` file exists at the root of the
+# wiki, and contains the relevant "start" and "end" markers for a safe space to
+# re-render the theme examples.
 #
 # runtime overrides, where CLI args override env vars:
 #
@@ -32,35 +37,35 @@ SCRIPT_WIKI_THEMES_END_MARKER="${OMB_WIKI_THEMES_END_MARKER:-<!-- THEME_GEN_END_
 
 VALID_ARGS=$(getopt -o p:f:s:e: --long wiki-path:,themes-file:,start-marker:,end-marker: -- "$@")
 if [[ $? -ne 0 ]]; then
-    exit 1;
+  exit 1;
 fi
 
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   case "$1" in
-    -p | --wiki-path)
-        # echo "Processing 'wiki-path' option. Input argument is '$2'"
-        SCRIPT_WIKI_PATH="$2"
-        shift 2
-        ;;
-    -f | --themes-file)
-        # echo "Processing 'themes-file' option. Input argument is '$2'"
-        SCRIPT_WIKI_THEMES_FILE="$2"
-        shift 2
-        ;;
-    -s | --start-marker)
-        # echo "Processing 'start-marker' option. Input argument is '$2'"
-        SCRIPT_WIKI_THEMES_START_MARKER="$2"
-        shift 2
-        ;;
-    -e | --end-marker)
-        # echo "Processing 'end-marker' option. Input argument is '$2'"
-        SCRIPT_WIKI_THEMES_END_MARKER="$2"
-        shift 2
-        ;;
-    --) shift;
-        break
-        ;;
+  -p | --wiki-path)
+    # echo "Processing 'wiki-path' option. Input argument is '$2'"
+    SCRIPT_WIKI_PATH="$2"
+    shift 2
+    ;;
+  -f | --themes-file)
+    # echo "Processing 'themes-file' option. Input argument is '$2'"
+    SCRIPT_WIKI_THEMES_FILE="$2"
+    shift 2
+    ;;
+  -s | --start-marker)
+    # echo "Processing 'start-marker' option. Input argument is '$2'"
+    SCRIPT_WIKI_THEMES_START_MARKER="$2"
+    shift 2
+    ;;
+  -e | --end-marker)
+    # echo "Processing 'end-marker' option. Input argument is '$2'"
+    SCRIPT_WIKI_THEMES_END_MARKER="$2"
+    shift 2
+    ;;
+  --) shift;
+      break
+      ;;
   esac
 done
 

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -28,72 +28,72 @@
 
 # first process current env vars, with some sensible default fallback values...
 
-SCRIPT_WIKI_PATH="${OMB_WIKI_PATH:-../oh-my-bash.wiki}"
-SCRIPT_WIKI_THEMES_FILE="${OMB_WIKI_THEMES_FILE:-Themes.md}"
-SCRIPT_WIKI_THEMES_START_MARKER="${OMB_WIKI_THEMES_START_MARKER:-<!-- THEME_GEN_START_MARKER -->}"
-SCRIPT_WIKI_THEMES_END_MARKER="${OMB_WIKI_THEMES_END_MARKER:-<!-- THEME_GEN_END_MARKER -->}"
+SCRIPT_WIKI_PATH=${OMB_WIKI_PATH:-../oh-my-bash.wiki}
+SCRIPT_WIKI_THEMES_FILE=${OMB_WIKI_THEMES_FILE:-Themes.md}
+SCRIPT_WIKI_THEMES_START_MARKER=${OMB_WIKI_THEMES_START_MARKER:-'<!-- THEME_GEN_START_MARKER -->'}
+SCRIPT_WIKI_THEMES_END_MARKER=${OMB_WIKI_THEMES_END_MARKER:-'<!-- THEME_GEN_END_MARKER -->'}
 
 # then process any cli args, if provided...
 
-VALID_ARGS=$(getopt -o p:f:s:e: --long wiki-path:,themes-file:,start-marker:,end-marker: -- "$@")
-if [[ $? -ne 0 ]]; then
-  exit 1;
+if ! VALID_ARGS=$(getopt -o p:f:s:e: --long wiki-path:,themes-file:,start-marker:,end-marker: -- "$@"); then
+  exit 2
 fi
 
-eval set -- "$VALID_ARGS"
-while [ : ]; do
-  case "$1" in
+eval "set -- $VALID_ARGS"
+while (($#)); do
+  case $1 in
   -p | --wiki-path)
     # echo "Processing 'wiki-path' option. Input argument is '$2'"
-    SCRIPT_WIKI_PATH="$2"
+    SCRIPT_WIKI_PATH=$2
     shift 2
     ;;
   -f | --themes-file)
     # echo "Processing 'themes-file' option. Input argument is '$2'"
-    SCRIPT_WIKI_THEMES_FILE="$2"
+    SCRIPT_WIKI_THEMES_FILE=$2
     shift 2
     ;;
   -s | --start-marker)
     # echo "Processing 'start-marker' option. Input argument is '$2'"
-    SCRIPT_WIKI_THEMES_START_MARKER="$2"
+    SCRIPT_WIKI_THEMES_START_MARKER=$2
     shift 2
     ;;
   -e | --end-marker)
     # echo "Processing 'end-marker' option. Input argument is '$2'"
-    SCRIPT_WIKI_THEMES_END_MARKER="$2"
+    SCRIPT_WIKI_THEMES_END_MARKER=$2
     shift 2
     ;;
-  --) shift;
-      break
-      ;;
+  --)
+    shift
+    break
+    ;;
   esac
 done
 
 # debug: this will either be adapted for the final script, or removed entirely..
-echo "current SCRIPT_WIKI_PATH: $SCRIPT_WIKI_PATH"
-echo "current SCRIPT_WIKI_THEMES_FILE: $SCRIPT_WIKI_THEMES_FILE"
-echo "current SCRIPT_WIKI_THEMES_START_MARKER: $SCRIPT_WIKI_THEMES_START_MARKER"
-echo "current SCRIPT_WIKI_THEMES_END_MARKER: $SCRIPT_WIKI_THEMES_END_MARKER"
+printf '%s\n' "current SCRIPT_WIKI_PATH: $SCRIPT_WIKI_PATH"
+printf '%s\n' "current SCRIPT_WIKI_THEMES_FILE: $SCRIPT_WIKI_THEMES_FILE"
+printf '%s\n' "current SCRIPT_WIKI_THEMES_START_MARKER: $SCRIPT_WIKI_THEMES_START_MARKER"
+printf '%s\n' "current SCRIPT_WIKI_THEMES_END_MARKER: $SCRIPT_WIKI_THEMES_END_MARKER"
 
 # verify that the OMB Wiki project exists...
-if [[ ! -d "$SCRIPT_WIKI_PATH" ]]; then
-  echo "ERROR: Wiki project path '$SCRIPT_WIKI_PATH' does not exist."
-  exit 1;
+if [[ ! -d $SCRIPT_WIKI_PATH ]]; then
+  printf '%s\n' "ERROR: Wiki project path '$SCRIPT_WIKI_PATH' does not exist."
+  exit 1
 fi
 
 # verify that the OMB Wiki contains the expected themes file...
-if [[ ! -f "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE" ]]; then
-  echo "ERROR: Wiki project has no themes file called '$SCRIPT_WIKI_THEMES_FILE'."
-  exit 1;
+if [[ ! -f $SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE ]]; then
+  printf '%s\n' "ERROR: Wiki project has no themes file called '$SCRIPT_WIKI_THEMES_FILE'."
+  exit 1
 fi
 
 # verify that the OMB Wiki contains the expected start and end markers...
-if ! (grep -q "$SCRIPT_WIKI_THEMES_START_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"); then
-  echo "ERROR: Wiki themes file does not contain start marker '$SCRIPT_WIKI_THEMES_START_MARKER'."
+if ! grep -q "$SCRIPT_WIKI_THEMES_START_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"; then
+  printf '%s\n' "ERROR: Wiki themes file does not contain start marker '$SCRIPT_WIKI_THEMES_START_MARKER'."
   exit 1
 fi
-if ! (grep -q "$SCRIPT_WIKI_THEMES_END_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"); then
-  echo "ERROR: Wiki themes file does not contain end marker '$SCRIPT_WIKI_THEMES_END_MARKER'."
+if ! grep -q "$SCRIPT_WIKI_THEMES_END_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"; then
+  printf '%s\n' "ERROR: Wiki themes file does not contain end marker '$SCRIPT_WIKI_THEMES_END_MARKER'."
   exit 1
 fi
 
@@ -107,21 +107,21 @@ markdown_text="$SCRIPT_WIKI_THEMES_START_MARKER\n\n"
 
 # now we can loop through the list and find all images in each theme directory...
 for theme in $theme_list; do
-  theme_dir="./themes/${theme}"
+  theme_dir=./themes/$theme
   image_list=$(find "$theme_dir" -type f -name "*.png" -o -name "*.jpg")
 
   # start preparing a theme example markdown block...
-  markdown_text="${markdown_text}## \`${theme}\`\n\n"
+  markdown_text="$markdown_text## \`$theme\`\n\n"
 
   # loop through the image list and add each image to the theme example entry...
-  if [[ ! -z "$image_list" ]]; then
+  if [[ ! -z $image_list ]]; then
     for image in $image_list; do
       # Extract filename and construct image URL
       image_filename=$(basename "$image")
-      image_url="https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/themes/$theme/$image_filename"
+      image_url=https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/themes/$theme/$image_filename
 
       # append image to theme example markdown block...
-      markdown_text="${markdown_text}![](${image_url})\n"
+      markdown_text="$markdown_text![]($image_url)\n"
     done
   else
     markdown_text="${markdown_text}WARNING: theme contains no example images.\n"
@@ -132,7 +132,7 @@ for theme in $theme_list; do
 done
 
 # inject the "end" marker for next run...
-markdown_text="$markdown_text$SCRIPT_WIKI_THEMES_END_MARKER"
+markdown_text=$markdown_text$SCRIPT_WIKI_THEMES_END_MARKER
 
 # now we can update the OMB Wiki "Themes" page directly...
 sed -i "/$SCRIPT_WIKI_THEMES_START_MARKER/,/$SCRIPT_WIKI_THEMES_END_MARKER/c\\

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -178,6 +178,12 @@ markdown_text="$markdown_text<!-- DO NOT EDIT THIS SECTION MANUALLY!\n     This 
 # now we can loop through the list and find all images in each theme directory...
 for theme in $theme_list; do
   theme_dir=$OMB_WORKING_TREE/themes/$theme
+
+  # Note: We skip the theme directories that do not have the actual theme file.
+  # The directory of renamed/removed themes may remain in the working tree when
+  # there are untracked files.
+  [[ -s $theme_dir/$theme.theme.sh || -s $theme_dir/$theme.theme.bash ]] || continue
+
   image_list=$(find "$theme_dir" -type f -name "*.png" -o -name "*.jpg")
 
   # start preparing a theme example markdown block...

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -202,6 +202,7 @@ for theme in $theme_list; do
     done
   else
     markdown_text="${markdown_text}WARNING: theme contains no example images.\n"
+    printf '\e[1;31m%s\e[m\n' "WARNING: theme '$theme' contains no example images." >&2
   fi
 
   # add one more newline before moving on...

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -7,15 +7,11 @@
 # alongside this repo, but with the understanding that this may not always be
 # true.
 #
-# it also assumes the associated `Themes.md` file exists at the root of the
-# wiki, and contains the relevant "start" and "end" markers for a safe space to
-# re-render the theme examples.
+# it also assumes the associated `Themes.md` file contains the relevant "start"
+# and "end" markers for a safe space to re-render the theme examples.
 #
 # runtime overrides, where CLI args override env vars:
 #
-# - set OMB Wiki project folder path
-#   - `OMB_WIKI_PATH` variable
-#   - `-p | --wiki-path` argument
 # - set OMB Wiki "themes" page path
 #   - `OMB_WIKI_THEMES_FILE` variable
 #   - `-f | --themes-file` argument
@@ -28,25 +24,19 @@
 
 # first process current env vars, with some sensible default fallback values...
 
-OMB_WIKI_PATH=${OMB_WIKI_PATH:-../oh-my-bash.wiki}
-OMB_WIKI_THEMES_FILE=${OMB_WIKI_THEMES_FILE:-Themes.md}
+OMB_WIKI_THEMES_FILE=${OMB_WIKI_THEMES_FILE:-../oh-my-bash.wiki/Themes.md}
 OMB_WIKI_THEMES_START_MARKER=${OMB_WIKI_THEMES_START_MARKER:-'<!-- OMB_WIKI_THEMES_START_MARKER -->'}
 OMB_WIKI_THEMES_END_MARKER=${OMB_WIKI_THEMES_END_MARKER:-'<!-- OMB_WIKI_THEMES_END_MARKER -->'}
 
 # then process any cli args, if provided...
 
-if ! VALID_ARGS=$(getopt -o p:f:s:e: --long wiki-path:,themes-file:,start-marker:,end-marker: -- "$@"); then
+if ! VALID_ARGS=$(getopt -o f:s:e: --long themes-file:,start-marker:,end-marker: -- "$@"); then
   exit 2
 fi
 
 eval "set -- $VALID_ARGS"
 while (($#)); do
   case $1 in
-  -p | --wiki-path)
-    # echo "Processing 'wiki-path' option. Input argument is '$2'"
-    OMB_WIKI_PATH=$2
-    shift 2
-    ;;
   -f | --themes-file)
     # echo "Processing 'themes-file' option. Input argument is '$2'"
     OMB_WIKI_THEMES_FILE=$2
@@ -70,29 +60,22 @@ while (($#)); do
 done
 
 # debug: this will either be adapted for the final script, or removed entirely..
-printf '%s\n' "current OMB_WIKI_PATH: $OMB_WIKI_PATH"
 printf '%s\n' "current OMB_WIKI_THEMES_FILE: $OMB_WIKI_THEMES_FILE"
 printf '%s\n' "current OMB_WIKI_THEMES_START_MARKER: $OMB_WIKI_THEMES_START_MARKER"
 printf '%s\n' "current OMB_WIKI_THEMES_END_MARKER: $OMB_WIKI_THEMES_END_MARKER"
 
-# verify that the OMB Wiki project exists...
-if [[ ! -d $OMB_WIKI_PATH ]]; then
-  printf '%s\n' "ERROR: Wiki project path '$OMB_WIKI_PATH' does not exist."
-  exit 1
-fi
-
-# verify that the OMB Wiki contains the expected themes file...
-if [[ ! -f $OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE ]]; then
-  printf '%s\n' "ERROR: Wiki project has no themes file called '$OMB_WIKI_THEMES_FILE'."
+# verify that the themes file exists...
+if [[ ! -f $OMB_WIKI_THEMES_FILE ]]; then
+  printf '%s\n' "ERROR: The themes file called '$OMB_WIKI_THEMES_FILE' does not exist."
   exit 1
 fi
 
 # verify that the OMB Wiki contains the expected start and end markers...
-if ! grep -q "$OMB_WIKI_THEMES_START_MARKER" "$OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE"; then
+if ! grep -q "$OMB_WIKI_THEMES_START_MARKER" "$OMB_WIKI_THEMES_FILE"; then
   printf '%s\n' "ERROR: Wiki themes file does not contain start marker '$OMB_WIKI_THEMES_START_MARKER'."
   exit 1
 fi
-if ! grep -q "$OMB_WIKI_THEMES_END_MARKER" "$OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE"; then
+if ! grep -q "$OMB_WIKI_THEMES_END_MARKER" "$OMB_WIKI_THEMES_FILE"; then
   printf '%s\n' "ERROR: Wiki themes file does not contain end marker '$OMB_WIKI_THEMES_END_MARKER'."
   exit 1
 fi
@@ -136,4 +119,4 @@ markdown_text=$markdown_text$OMB_WIKI_THEMES_END_MARKER
 
 # now we can update the OMB Wiki "Themes" page directly...
 sed -i "/$OMB_WIKI_THEMES_START_MARKER/,/$OMB_WIKI_THEMES_END_MARKER/c\\
-$markdown_text" "$OMB_WIKI_PATH/$OMB_WIKI_THEMES_FILE"
+$markdown_text" "$OMB_WIKI_THEMES_FILE"

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -187,7 +187,7 @@ for theme in $theme_list; do
       image_url=https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/themes/$theme/$image_filename
 
       # append image to theme example markdown block...
-      markdown_text="$markdown_text![]($image_url)\n"
+      markdown_text="$markdown_text![$theme]($image_url)\n"
     done
   else
     markdown_text="${markdown_text}WARNING: theme contains no example images.\n"

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -9,34 +9,62 @@
 #
 # it also assumes the associated `Themes.md` file contains the relevant "start"
 # and "end" markers for a safe space to re-render the theme examples.
-#
-# runtime overrides, where CLI args override env vars:
-#
-# - set OMB Wiki "themes" page path
-#   - `OMB_WIKI_THEMES_FILE` variable
-#   - `-f | --themes-file` argument
-# - set OMB Wiki "themes" page "start" marker
-#   - `OMB_WIKI_THEMES_START_MARKER` variable
-#   - `-s | --start-marker` argument
-# - set OMB Wiki "themes" page "end" marker
-#   - `OMB_WIKI_THEMES_END_MARKER` variable
-#   - `-e | --end-marker` argument
+
+function print_usage {
+  printf '%s\n' \
+         'usage: tools/update-wiki-themes.sh [[-f|--themes-file] FILE |' \
+         '            [-s|--start-marker] START | [-e|--end-marker] END]' \
+         ''
+}
+
+function print_help {
+  print_usage
+  printf '%s\n' \
+         'OPTIONS' \
+         '' \
+         '    When both the CLI argument and the environment variable are specified, the' \
+         '    CLI argument overrides the envrionment variable.' \
+         '' \
+         '    -f, --themes-file FILE' \
+         '        Set OMB Wiki "themes" page path.  This can also be specified through' \
+         '        the environment variable "OMB_WIKI_THEMES_FILE".  The default is' \
+         '        "./wiki/Themes.md"' \
+         '' \
+         '    -s | --start-marker START' \
+         '        Set OMB Wiki "themes" page "start" marker.  This can also be specified' \
+         '        through the environment variable "OMB_WIKI_THEMES_START_MARKER".  The' \
+         '        default is "<!-- OMB_WIKI_THEMES_START_MARKER -->"' \
+         '' \
+         '    -e | --end-marker END' \
+         '        Set OMB Wiki "themes" page "end" marker.  This can also be specified' \
+         '        through the environment variable "OMB_WIKI_THEMES_END_MARKER".  The' \
+         '        default is "<!-- OMB_WIKI_THEMES_END_MARKER -->"' \
+         '' \
+         '    --help' \
+         '        Print this help.' \
+         ''
+}
 
 # first process current env vars, with some sensible default fallback values...
 
 OMB_WIKI_THEMES_FILE=${OMB_WIKI_THEMES_FILE:-../oh-my-bash.wiki/Themes.md}
 OMB_WIKI_THEMES_START_MARKER=${OMB_WIKI_THEMES_START_MARKER:-'<!-- OMB_WIKI_THEMES_START_MARKER -->'}
 OMB_WIKI_THEMES_END_MARKER=${OMB_WIKI_THEMES_END_MARKER:-'<!-- OMB_WIKI_THEMES_END_MARKER -->'}
+OMB_WIKI_FLAG_HELP=
 
 # then process any cli args, if provided...
 
-if ! VALID_ARGS=$(getopt -o f:s:e: --long themes-file:,start-marker:,end-marker: -- "$@"); then
+if ! VALID_ARGS=$(getopt -o f:s:e: --long help,themes-file:,start-marker:,end-marker: -- "$@"); then
   exit 2
 fi
 
 eval "set -- $VALID_ARGS"
 while (($#)); do
   case $1 in
+  --help)
+    OMB_WIKI_FLAG_HELP=set
+    shift
+    ;;
   -f | --themes-file)
     # echo "Processing 'themes-file' option. Input argument is '$2'"
     OMB_WIKI_THEMES_FILE=$2
@@ -56,8 +84,22 @@ while (($#)); do
     shift
     break
     ;;
+  *)
+    break
+    ;;
   esac
 done
+
+if (($#)); then
+  printf '%s\n' 'unrecognized arguments are specified.' >&2
+  print_usage >&2
+  exit 2
+fi
+
+if [[ $OMB_WIKI_FLAG_HELP ]]; then
+  print_help
+  exit 0
+fi
 
 # debug: this will either be adapted for the final script, or removed entirely..
 printf '%s\n' "current OMB_WIKI_THEMES_FILE: $OMB_WIKI_THEMES_FILE"

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+# this script aims to simplify the process of updating the theme examples page in the GitHub Wiki.
+#
+# it is built with the assumption that the relevant wiki is cloned with Git alongside this repo, but with the understanding that this may not always be true.
+#
+# it also assumes the associated `Themes.md` file exists at the root of the wiki, and contains the relevant "start" and "end" markers for a safe space to re-render the theme examples.
+#
+# runtime overrides, where CLI args override env vars:
+#
+# - set OMB Wiki project folder path
+#   - `OMB_WIKI_PATH` variable
+#   - `-p | --wiki-path` argument
+# - set OMB Wiki "themes" page path
+#   - `OMB_WIKI_THEMES_FILE` variable
+#   - `-f | --themes-file` argument
+# - set OMB Wiki "themes" page "start" marker
+#   - `OMB_WIKI_THEMES_START_MARKER` variable
+#   - `-s | --start-marker` argument
+# - set OMB Wiki "themes" page "end" marker
+#   - `OMB_WIKI_THEMES_END_MARKER` variable
+#   - `-e | --end-marker` argument
+
+# first process current env vars, with some sensible default fallback values...
+
+SCRIPT_WIKI_PATH="${OMB_WIKI_PATH:-../oh-my-bash.wiki}"
+SCRIPT_WIKI_THEMES_FILE="${OMB_WIKI_THEMES_FILE:-Themes.md}"
+SCRIPT_WIKI_THEMES_START_MARKER="${OMB_WIKI_THEMES_START_MARKER:-<!-- THEME_GEN_START_MARKER -->}"
+SCRIPT_WIKI_THEMES_END_MARKER="${OMB_WIKI_THEMES_END_MARKER:-<!-- THEME_GEN_END_MARKER -->}"
+
+# then process any cli args, if provided...
+
+VALID_ARGS=$(getopt -o p:f:s:e: --long wiki-path:,themes-file:,start-marker:,end-marker: -- "$@")
+if [[ $? -ne 0 ]]; then
+    exit 1;
+fi
+
+eval set -- "$VALID_ARGS"
+while [ : ]; do
+  case "$1" in
+    -p | --wiki-path)
+        # echo "Processing 'wiki-path' option. Input argument is '$2'"
+        SCRIPT_WIKI_PATH="$2"
+        shift 2
+        ;;
+    -f | --themes-file)
+        # echo "Processing 'themes-file' option. Input argument is '$2'"
+        SCRIPT_WIKI_THEMES_FILE="$2"
+        shift 2
+        ;;
+    -s | --start-marker)
+        # echo "Processing 'start-marker' option. Input argument is '$2'"
+        SCRIPT_WIKI_THEMES_START_MARKER="$2"
+        shift 2
+        ;;
+    -e | --end-marker)
+        # echo "Processing 'end-marker' option. Input argument is '$2'"
+        SCRIPT_WIKI_THEMES_END_MARKER="$2"
+        shift 2
+        ;;
+    --) shift;
+        break
+        ;;
+  esac
+done
+
+# debug: this will either be adapted for the final script, or removed entirely..
+echo "current SCRIPT_WIKI_PATH: $SCRIPT_WIKI_PATH"
+echo "current SCRIPT_WIKI_THEMES_FILE: $SCRIPT_WIKI_THEMES_FILE"
+echo "current SCRIPT_WIKI_THEMES_START_MARKER: $SCRIPT_WIKI_THEMES_START_MARKER"
+echo "current SCRIPT_WIKI_THEMES_END_MARKER: $SCRIPT_WIKI_THEMES_END_MARKER"
+
+# verify that the OMB Wiki project exists...
+if [[ ! -d "$SCRIPT_WIKI_PATH" ]]; then
+  echo "ERROR: Wiki project path '$SCRIPT_WIKI_PATH' does not exist."
+  exit 1;
+fi
+
+# verify that the OMB Wiki contains the expected themes file...
+if [[ ! -f "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE" ]]; then
+  echo "ERROR: Wiki project has no themes file called '$SCRIPT_WIKI_THEMES_FILE'."
+  exit 1;
+fi
+
+# verify that the OMB Wiki contains the expected start and end markers...
+if ! (grep -q "$SCRIPT_WIKI_THEMES_START_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"); then
+  echo "ERROR: Wiki themes file does not contain start marker '$SCRIPT_WIKI_THEMES_START_MARKER'."
+  exit 1
+fi
+if ! (grep -q "$SCRIPT_WIKI_THEMES_END_MARKER" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"); then
+  echo "ERROR: Wiki themes file does not contain end marker '$SCRIPT_WIKI_THEMES_END_MARKER'."
+  exit 1
+fi
+
+# now we get onto the fun stuff, lets get a list of all current themes...
+
+# find all themes in the current themes directory...
+theme_list=$(find "./themes" -mindepth 1 -maxdepth 1 -type d -print | sort | xargs -n1 basename)
+
+# prepare a variable to hold generated content, starting with with the "start" marker for next run...
+markdown_text="$SCRIPT_WIKI_THEMES_START_MARKER\n\n"
+
+# now we can loop through the list and find all images in each theme directory...
+for theme in $theme_list; do
+  theme_dir="./themes/${theme}"
+  image_list=$(find "$theme_dir" -type f -name "*.png" -o -name "*.jpg")
+
+  # start preparing a theme example markdown block...
+  markdown_text="${markdown_text}## \`${theme}\`\n\n"
+
+  # loop through the image list and add each image to the theme example entry...
+  if [[ ! -z "$image_list" ]]; then
+    for image in $image_list; do
+      # Extract filename and construct image URL
+      image_filename=$(basename "$image")
+      image_url="https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/themes/$theme/$image_filename"
+
+      # append image to theme example markdown block...
+      markdown_text="${markdown_text}![](${image_url})\n"
+    done
+  else
+    markdown_text="${markdown_text}WARNING: theme contains no example images.\n"
+  fi
+
+  # add one more newline before moving on...
+  markdown_text="$markdown_text\n"
+done
+
+# inject the "end" marker for next run...
+markdown_text="$markdown_text$SCRIPT_WIKI_THEMES_END_MARKER"
+
+# now we can update the OMB Wiki "Themes" page directly...
+sed -i "/$SCRIPT_WIKI_THEMES_START_MARKER/,/$SCRIPT_WIKI_THEMES_END_MARKER/c\\
+$markdown_text" "$SCRIPT_WIKI_PATH/$SCRIPT_WIKI_THEMES_FILE"

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -201,5 +201,6 @@ done
 markdown_text=$markdown_text$OMB_WIKI_THEMES_END_MARKER
 
 # now we can update the OMB Wiki "Themes" page directly...
-sed -i "/$OMB_WIKI_THEMES_START_MARKER/,/$OMB_WIKI_THEMES_END_MARKER/c\\
-$markdown_text" "$OMB_WIKI_THEMES_FILE"
+sed "/$OMB_WIKI_THEMES_START_MARKER/,/$OMB_WIKI_THEMES_END_MARKER/c\\
+$markdown_text" "$OMB_WIKI_THEMES_FILE" > "$OMB_WIKI_THEMES_FILE.part" &&
+  mv -f "$OMB_WIKI_THEMES_FILE.part" "$OMB_WIKI_THEMES_FILE"

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -80,6 +80,10 @@ OMB_WIKI_THEMES_START_MARKER=${OMB_WIKI_THEMES_START_MARKER:-'<!-- OMB_WIKI_THEM
 OMB_WIKI_THEMES_END_MARKER=${OMB_WIKI_THEMES_END_MARKER:-'<!-- OMB_WIKI_THEMES_END_MARKER -->'}
 OMB_WIKI_FLAG_HELP=
 
+declare -A OMB_THEME_SUBTITLE=(
+  [font]='(default theme)'
+)
+
 # then process any cli args, if provided...
 
 if ! VALID_ARGS=$(getopt -o p:f:s:e: --long help,omb-working-tree:themes-file:,start-marker:,end-marker: -- "$@"); then
@@ -177,7 +181,8 @@ for theme in $theme_list; do
   image_list=$(find "$theme_dir" -type f -name "*.png" -o -name "*.jpg")
 
   # start preparing a theme example markdown block...
-  markdown_text="$markdown_text## \`$theme\`\n\n"
+  title="\`$theme\`${OMB_THEME_SUBTITLE[$theme]:+ ${OMB_THEME_SUBTITLE[$theme]}}"
+  markdown_text="$markdown_text## $title\n\n"
 
   # loop through the image list and add each image to the theme example entry...
   if [[ ! -z $image_list ]]; then

--- a/tools/update-wiki-themes.sh
+++ b/tools/update-wiki-themes.sh
@@ -169,6 +169,7 @@ theme_list=$(find "$OMB_WORKING_TREE/themes" -mindepth 1 -maxdepth 1 -type d -pr
 
 # prepare a variable to hold generated content, starting with with the "start" marker for next run...
 markdown_text="$OMB_WIKI_THEMES_START_MARKER\n\n"
+markdown_text="$markdown_text<!-- DO NOT EDIT THIS SECTION MANUALLY!\n     This section will be automatically overwritten. -->\n\n"
 
 # now we can loop through the list and find all images in each theme directory...
 for theme in $theme_list; do


### PR DESCRIPTION
I got bored, and I was looking through OMB themes, when I noticed that there were a great many discrepancies between the "Themes" page in Wiki and the "themes" folder in this repo...

tl;dr: I scripted an update process for the Wiki file that uses content as it currently exists inside this repo.

but I found I was still bored, so I made it configurable via either environment variables or CLI args.. and documented it's usage at the top of the script.

then I tested it a whole bunch to make sure I couldn't break it..

anyways, question for the repo maintainers: would this perhaps be helpful to you guys?

---

note: this does require one small change to the `Themes.md` file, specifically as follows:

```diff
diff --git a/Themes.md b/Themes.md
index 9917bb2..4e77dca 100644
--- a/Themes.md
+++ b/Themes.md
@@ -1,8 +1,10 @@
 ## Where to find the themes?
 
 The themes are all located inside the themes folder [here](https://github.com/ohmybash/oh-my-bash/tree/master/themes)
 
+<!-- THEME_GEN_START_MARKER -->
+
 ## `90210`
 
 ![](https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/themes/90210/90210-dark.png)
 
@@ -275,7 +277,9 @@ The themes are all located inside the themes folder [here](https://github.com/oh
 ## `zork`
 
 ![](https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/themes/zork/zork-dark.png)
 
+<!-- THEME_GEN_END_MARKER -->
+
 _*Credit:*_
 
 All credits go to [Israel-Laguan](https://github.com/Israel-Laguan). Thank you so much for your hard work with the screenshots here :)

```