### PR TITLE
plugins/asdf: Add `asdf` extendable version manager plugin

### DIFF
--- a/completions/asdf.completion.sh
+++ b/completions/asdf.completion.sh
@@ -3,6 +3,6 @@
 # Depends on the `asdf` plugin.
 
 # Only load the completions if the ASDF_DIR variable was set.
-if [[ -v ASDF_DIR ]]; then
+if [[ ${ASDF_DIR+set} ]]; then
   . "$ASDF_DIR/completions/asdf.bash"
 fi

--- a/completions/asdf.completion.sh
+++ b/completions/asdf.completion.sh
@@ -1,0 +1,8 @@
+#! bash oh-my-bash.module
+# Bash completion support for the `asdf` command.
+# Depends on the `asdf` plugin.
+
+# Only load the completions if the ASDF_DIR variable was set.
+if [[ -v ASDF_DIR ]]; then
+  . "$ASDF_DIR/completions/asdf.bash"
+fi

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -26,6 +26,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | Plugin          | Description                                                                                                         |
 | --------------- | ------------------------------------------------------------------------------------------------------------------- |
 | ansible         | Configuration management tool used to automate the provisioning, configuration, and management of computer systems. |
+| [asdf](asdf)    | [asdf](https://asdf-vm.com) is a tool version manager to allow installing different versions of Node.js, Ruby, Golang, etc.
 | aws             | Tools for interacting with Amazon Web Services (AWS)                                                                |
 | bash-preexec    | Tool allowing execution of commands before they are executed in Bash.                                               |
 | bashmarks       | Utility facilitating directory navigation via bookmarks in Bash.                                                    |

--- a/plugins/asdf/README.md
+++ b/plugins/asdf/README.md
@@ -19,7 +19,7 @@ Add [oh-my-bash](https://ohmybash.github.io) integration with [asdf](https://git
     completions=(asdf)
     ```
 
-### Usage
+## Usage
 
 See the [asdf usage documentation](https://github.com/asdf-vm/asdf#usage) for information on how to use asdf:
 

--- a/plugins/asdf/README.md
+++ b/plugins/asdf/README.md
@@ -2,7 +2,7 @@
 
 Add [oh-my-bash](https://ohmybash.github.io) integration with [asdf](https://github.com/asdf-vm/asdf), the extendable version manager, with support for Ruby, Node.js, Elixir, Erlang and more.
 
-### Installation
+## Installation
 
 1. [Install asdf](https://github.com/asdf-vm/asdf#setup) by running the following:
     ``` bash

--- a/plugins/asdf/README.md
+++ b/plugins/asdf/README.md
@@ -1,0 +1,29 @@
+# asdf plugin
+
+Add [oh-my-bash](https://ohmybash.github.io) integration with [asdf](https://github.com/asdf-vm/asdf), the extendable version manager, with support for Ruby, Node.js, Elixir, Erlang and more.
+
+### Installation
+
+1. [Install asdf](https://github.com/asdf-vm/asdf#setup) by running the following:
+    ``` bash
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf
+    ```
+
+2. Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.bashrc`.
+    ``` sh
+    plugins=(asdf)
+    ```
+
+2. Enable the completions by adding it to your oh-my-bash `completions` definition in `~/.bashrc`.
+    ``` sh
+    completions=(asdf)
+    ```
+
+### Usage
+
+See the [asdf usage documentation](https://github.com/asdf-vm/asdf#usage) for information on how to use asdf:
+
+``` bash
+asdf plugin add nodejs
+asdf install nodejs latest
+```

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -1,0 +1,26 @@
+#! bash oh-my-bash.module
+# asdf.plugin.sh: asdf plugin for oh-my-bash.
+
+# Custom ASDF_DIR location
+if [[ -v ASDF_DIR ]]; then
+  . "$ASDF_DIR/asdf.sh"
+
+# Standard install location
+elif [[ -f "${XDG_CONFIG_HOME:-$HOME}/.asdf/asdf.sh" ]]; then
+  ASDF_DIR="${XDG_CONFIG_HOME:-$HOME}/.asdf"
+  . "${ASDF_DIR}/asdf.sh"
+
+# Arch Linux / AUR Package
+elif [[ -f "/opt/asdf-vm/asdf.sh" ]]; then
+  ASDF_DIR="/opt/asdf-vm"
+  . /opt/asdf-vm/asdf.sh
+
+# Homebrew
+elif _omb_util_command_exists brew; then
+  __ASDF_PREFIX="$(brew --prefix asdf)"
+  if [[ -f "$__ASDF_PREFIX/libexec/asdf.sh" ]]; then
+    ASDF_DIR="$__ASDF_PREFIX/libexec"
+    . "$ASDF_DIR/asdf.sh"
+  fi
+  unset __ASDF_PREFIX
+fi

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -9,9 +9,14 @@
 if [[ ${ASDF_DIR+set} ]]; then
   . "$ASDF_DIR/asdf.sh"
 
-# Standard install location
-elif [[ -f "${XDG_CONFIG_HOME:-$HOME}/.asdf/asdf.sh" ]]; then
-  ASDF_DIR="${XDG_CONFIG_HOME:-$HOME}/.asdf"
+# Home
+elif [[ -f "$HOME/.asdf/asdf.sh" ]]; then
+  ASDF_DIR="$HOME/.asdf"
+  . "${ASDF_DIR}/asdf.sh"
+
+# Config
+elif [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/asdf/asdf.sh" ]]; then
+  ASDF_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/asdf"
   . "${ASDF_DIR}/asdf.sh"
 
 # Arch Linux / AUR Package

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -6,7 +6,7 @@
 # Fork of the oh-my-zsh asdf plugin
 
 # Custom ASDF_DIR location
-if [[ -v ${ASDF_DIR+set} ]]; then
+if [[ ${ASDF_DIR+set} ]]; then
   . "$ASDF_DIR/asdf.sh"
 
 # Standard install location
@@ -22,9 +22,9 @@ elif [[ -f "/opt/asdf-vm/asdf.sh" ]]; then
 # Homebrew
 elif _omb_util_command_exists brew; then
   _omb_plugin_asdf__prefix="$(brew --prefix asdf)"
-  if [[ -f "$__ASDF_PREFIX/libexec/asdf.sh" ]]; then
-    ASDF_DIR="$__ASDF_PREFIX/libexec"
+  if [[ -f "$_omb_plugin_asdf__prefix/libexec/asdf.sh" ]]; then
+    ASDF_DIR="$_omb_plugin_asdf__prefix/libexec"
     . "$ASDF_DIR/asdf.sh"
   fi
-  unset -v __ASDF_PREFIX
+  unset -v _omb_plugin_asdf__prefix
 fi

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -2,7 +2,7 @@
 # asdf.plugin.sh: asdf plugin for oh-my-bash.
 
 # Custom ASDF_DIR location
-if [[ -v ASDF_DIR ]]; then
+if [[ -v ${ASDF_DIR+set} ]]; then
   . "$ASDF_DIR/asdf.sh"
 
 # Standard install location

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -17,7 +17,7 @@ elif [[ -f "/opt/asdf-vm/asdf.sh" ]]; then
 
 # Homebrew
 elif _omb_util_command_exists brew; then
-  __ASDF_PREFIX="$(brew --prefix asdf)"
+  _omb_plugin_asdf__prefix="$(brew --prefix asdf)"
   if [[ -f "$__ASDF_PREFIX/libexec/asdf.sh" ]]; then
     ASDF_DIR="$__ASDF_PREFIX/libexec"
     . "$ASDF_DIR/asdf.sh"

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -22,5 +22,5 @@ elif _omb_util_command_exists brew; then
     ASDF_DIR="$__ASDF_PREFIX/libexec"
     . "$ASDF_DIR/asdf.sh"
   fi
-  unset __ASDF_PREFIX
+  unset -v __ASDF_PREFIX
 fi

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -1,7 +1,7 @@
 #! bash oh-my-bash.module
 # asdf.plugin.sh: asdf plugin for oh-my-bash.
-# Author: Rob Loach (https://robloach.net)
-# Author: prodrigues1912 (https://github.com/prodrigues1912)
+# Author: @RobLoach (https://github.com/robloach)
+# Author: @prodrigues1912 (https://github.com/prodrigues1912)
 # Originally suggested in https://github.com/ohmybash/oh-my-bash/pull/310
 # Fork of the oh-my-zsh asdf plugin
 

--- a/plugins/asdf/asdf.plugin.sh
+++ b/plugins/asdf/asdf.plugin.sh
@@ -1,5 +1,9 @@
 #! bash oh-my-bash.module
 # asdf.plugin.sh: asdf plugin for oh-my-bash.
+# Author: Rob Loach (https://robloach.net)
+# Author: prodrigues1912 (https://github.com/prodrigues1912)
+# Originally suggested in https://github.com/ohmybash/oh-my-bash/pull/310
+# Fork of the oh-my-zsh asdf plugin
 
 # Custom ASDF_DIR location
 if [[ -v ${ASDF_DIR+set} ]]; then


### PR DESCRIPTION
This adds a plugin to load the [asdf version manager](https://github.com/asdf-vm/asdf) through *oh-my-bash*. It's roughly based off of the [original pull request](https://github.com/ohmybash/oh-my-bash/pull/310), moves to the bash syntax, and allows checking for the `ASDF_DIR` variable before hitting the file system.

```
asdf plugin add nodejs
asdf install nodejs latest
```