### PR TITLE
defaults.completion.sh Syntax Error on macOS with Bash version 3.2.57

### DIFF
--- a/completions/defaults.completion.sh
+++ b/completions/defaults.completion.sh
@@ -66,7 +66,7 @@ function _defaults {
 
   # Both a domain and command have been specified
 
-  if [[ ${COMP_WORDS[1]} == @(${cmds// /|}) ]]; then
+  if [[ ${COMP_WORDS[1]} == [${cmds// /|}] ]]; then
     cmd=${COMP_WORDS[1]}
     domain=${COMP_WORDS[2]}
     key_index=3
@@ -78,7 +78,7 @@ function _defaults {
       domain="-app ${COMP_WORDS[3]}"
       key_index=4
     fi
-  elif [[ ${COMP_WORDS[2]} == "-currentHost" && ${COMP_WORDS[2]} == @(${cmds// /|}) ]]; then
+  elif [[ ${COMP_WORDS[2]} == "-currentHost" && ${COMP_WORDS[2]} == [${cmds// /|}] ]]; then
     cmd=${COMP_WORDS[2]}
     domain=${COMP_WORDS[3]}
     key_index=4
@@ -90,7 +90,7 @@ function _defaults {
       domain="-app ${COMP_WORDS[4]}"
       key_index=5
     fi
-  elif [[ ${COMP_WORDS[3]} == "-host" && ${COMP_WORDS[3]} == @(${cmds// /|}) ]]; then
+  elif [[ ${COMP_WORDS[3]} == "-host" && ${COMP_WORDS[3]} == [${cmds// /|}] ]]; then
     cmd=${COMP_WORDS[3]}
     domain=${COMP_WORDS[4]}
     key_index=5


### PR DESCRIPTION
After updating Oh My Bash, I encountered a syntax error in the `defaults.completion.sh` file, specifically at line 69. 
The error message is:

```bash
-bash: /Users/username/.oh-my-bash/completions/defaults.completion.sh: line 69: syntax error in conditional expression: unexpected token `('
-bash: /Users/username/.oh-my-bash/completions/defaults.completion.sh: line 69: syntax error near `@($'
-bash: /Users/username/.oh-my-bash/completions/defaults.completion.sh: line 69: `  if [[ ${COMP_WORDS[1]} == @(${cmds// /|}) ]]; then'
```

This error seems to be related to the use of `@(...)` syntax, which might not be fully supported in my Bash version.

**Steps to Reproduce**

1. Update Oh My Bash to the latest version.
2. Open a new terminal session.
3. The error message appears.

**Expected Behavior**

Oh My Bash should load without errors, and tab completion should work correctly.

**Actual Behavior**

The syntax error prevents Oh My Bash from loading properly, and tab completion might be affected.

**Environment**

* **Operating System:** macOS Sonoma 14.6.1
* **Bash Version:** 3.2.57(1)-release
* **Oh My Bash Version:** (latest)

**Workaround**

I was able to temporarily fix the issue by reverting commit `74012c548c2fbd3f38a9c04dbf4e2cb3e38493b1`.

**Possible Solution**

* Consider using a more compatible syntax in `defaults.completion.sh` or adding a version check to avoid using features that might not be supported in older Bash versions.