### PR TITLE
Add Colored Man Pages plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -33,6 +33,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | battery         | Plugin related to monitoring and managing battery on computer systems.                                              |
 | brew            | Package manager for macOS and Linux facilitating software installation and management.                              |
 | bu              | Insufficient information provided to give a precise description.                                                    |
+| colored-man-pages | Adds a few colors to `man` pages.
 | chezmoi         | Dotfile management tool enabling management of user environment configuration.                                      |
 | dotnet          | This plugin provides completion and useful aliases for .NET Core CLI.                                               |
 | fasd            | Utility easing filesystem navigation through shortcuts and abbreviated commands.                                    |

--- a/plugins/colored-man-pages/README.md
+++ b/plugins/colored-man-pages/README.md
@@ -4,6 +4,15 @@ Adds colors to [`man`](https://man7.org/linux/man-pages/man1/man.1.html) pages.
 
 To use it, add `colored-man-pages` to the plugins array in your .bashrc file.
 
-```
+```bash
 plugins=(... colored-man-pages)
+```
+
+It will also automatically colorize man pages displayed by `dman` or `debman`,
+from [`debian-goodies`](https://packages.debian.org/stable/debian-goodies).
+
+You can also try to color other pages by prefixing the respective command with `colored`:
+
+```bash
+colored git help clone
 ```

--- a/plugins/colored-man-pages/README.md
+++ b/plugins/colored-man-pages/README.md
@@ -1,0 +1,9 @@
+# Colored Man Pages Plugin
+
+Adds colors to [`man`](https://man7.org/linux/man-pages/man1/man.1.html) pages.
+
+To use it, add `colored-man-pages` to the plugins array in your .bashrc file.
+
+```
+plugins=(... colored-man-pages)
+```

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -1,0 +1,47 @@
+#! bash oh-my-bash.module
+
+# Safety get the colors.
+if tput setaf 1 &> /dev/null; then
+  COLORED_MAN_PAGES_BLACK=$(tput setaf 0)
+  COLORED_MAN_PAGES_RED=$(tput setaf 1)
+  COLORED_MAN_PAGES_GREEN=$(tput setaf 2)
+  COLORED_MAN_PAGES_YELLOW=$(tput setaf 3)
+  COLORED_MAN_PAGES_BLUE=$(tput setaf 4)
+  COLORED_MAN_PAGES_MAGENTA=$(tput setaf 5)
+  COLORED_MAN_PAGES_CYAN=$(tput setaf 6)
+  COLORED_MAN_PAGES_WHITE=$(tput setaf 7)
+  COLORED_MAN_PAGES_BOLD=$(tput bold)
+  COLORED_MAN_PAGES_RESET=$(tput sgr0)
+
+  # Extra Styles
+  export LESS_TERMCAP_mr=$(tput rev) # Reverse
+  export LESS_TERMCAP_mh=$(tput dim) # Half Bright
+  export LESS_TERMCAP_ZN=$(tput ssubm) # Subscript
+  export LESS_TERMCAP_ZV=$(tput rsubm) # Reverse Superscript
+  export LESS_TERMCAP_ZO=$(tput ssupm) # Subscript
+  export LESS_TERMCAP_ZW=$(tput rsupm) # Reverse Superscript
+else
+  COLORED_MAN_PAGES_BLACK="\033[1;30m"
+  COLORED_MAN_PAGES_RED="\033[1;31m"
+  COLORED_MAN_PAGES_GREEN="\033[1;32m"
+  COLORED_MAN_PAGES_YELLOW="\033[1;33m"
+  COLORED_MAN_PAGES_BLUE="\033[1;34m"
+  COLORED_MAN_PAGES_MAGENTA="\033[1;35m"
+  COLORED_MAN_PAGES_CYAN="\033[1;36m"
+  COLORED_MAN_PAGES_WHITE="\033[1;37m"
+  COLORED_MAN_PAGES_BOLD=""
+  COLORED_MAN_PAGES_RESET="\033[m"
+fi
+
+# Bold and Blinking
+export LESS_TERMCAP_mb=$COLORED_MAN_PAGES_GREEN
+export LESS_TERMCAP_md=$COLORED_MAN_PAGES_BOLD$COLORED_MAN_PAGES_GREEN
+export LESS_TERMCAP_me=$COLORED_MAN_PAGES_RESET
+
+# Standout Mode
+export LESS_TERMCAP_so=$COLORED_MAN_PAGES_YELLOW
+export LESS_TERMCAP_se=$COLORED_MAN_PAGES_RESET
+
+# Underline
+export LESS_TERMCAP_us=$COLORED_MAN_PAGES_MAGENTA
+export LESS_TERMCAP_ue=$COLORED_MAN_PAGES_RESET

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -7,17 +7,17 @@
 
 # Adds the LESS_TERMCAP_* variables to color the man pages.
 function colored() {
-  local -x LESS_TERMCAP_mb=${_omb_term_green}
-  local -x LESS_TERMCAP_md=${_omb_term_bold_green}
+  local -x LESS_TERMCAP_mb=${_omb_term_red}
+  local -x LESS_TERMCAP_md=${_omb_term_bold_red}
   local -x LESS_TERMCAP_me=${_omb_term_reset}
   local -x LESS_TERMCAP_so=${_omb_term_bold_yellow}
   local -x LESS_TERMCAP_se=${_omb_term_reset}
-  local -x LESS_TERMCAP_us=${_omb_term_purple}
+  local -x LESS_TERMCAP_us=${_omb_term_green}
   local -x LESS_TERMCAP_ue=${_omb_term_reset}
 
   # Prefer `less` whenever available, since we specifically configured
   # environment for it.
-  local -x PAGER="${commands[less]:-$PAGER}"
+  local -x PAGER=$(type -P less || _omb_util_print "$PAGER")
   local -x GROFF_NO_SGR=1
 
   command "$@"

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -6,14 +6,14 @@
 # https://github.com/ohmyzsh/ohmyzsh/blob/6bc4c80c7db072a0d2d265eb3589bbe52e0d2737/plugins/colored-man-pages/colored-man-pages.plugin.zsh
 
 # Adds the LESS_TERMCAP_* variables to color the man pages.
-function colored() {
-  local -x LESS_TERMCAP_mb=${_omb_term_red}
-  local -x LESS_TERMCAP_md=${_omb_term_bold_red}
-  local -x LESS_TERMCAP_me=${_omb_term_reset}
-  local -x LESS_TERMCAP_so=${_omb_term_bold_yellow}
-  local -x LESS_TERMCAP_se=${_omb_term_reset}
-  local -x LESS_TERMCAP_us=${_omb_term_green}
-  local -x LESS_TERMCAP_ue=${_omb_term_reset}
+function colored {
+  local -x LESS_TERMCAP_mb=$_omb_term_red
+  local -x LESS_TERMCAP_md=$_omb_term_bold_red
+  local -x LESS_TERMCAP_me=$_omb_term_reset
+  local -x LESS_TERMCAP_so=$_omb_term_bold_yellow
+  local -x LESS_TERMCAP_se=$_omb_term_reset
+  local -x LESS_TERMCAP_us=$_omb_term_green
+  local -x LESS_TERMCAP_ue=$_omb_term_reset
 
   # Prefer `less` whenever available, since we specifically configured
   # environment for it.
@@ -25,18 +25,18 @@ function colored() {
 
 # Wrapper for man to colorize the output.
 _omb_util_binary_exists man &&
-function man {
-  colored "$FUNCNAME" "$@"
-}
+  function man {
+    colored "$FUNCNAME" "$@"
+  }
 
 # Wrapper for dman to colorize the output.
 _omb_util_binary_exists dman &&
-function dman {
-  colored "$FUNCNAME" "$@"
-}
+  function dman {
+    colored "$FUNCNAME" "$@"
+  }
 
 # Wrapper for debman to colorize the output.
 _omb_util_binary_exists debman &&
-function debman {
-  colored "$FUNCNAME" "$@"
-}
+  function debman {
+    colored "$FUNCNAME" "$@"
+  }

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -1,16 +1,41 @@
 #! bash oh-my-bash.module
+#
+# Colored Man Pages Plugin
+#
+# This plugin is based on the following Oh-My-Zsh plugin:
+# https://github.com/ohmyzsh/ohmyzsh/blob/6bc4c80c7db072a0d2d265eb3589bbe52e0d2737/plugins/colored-man-pages/colored-man-pages.plugin.zsh
 
-# Bold and Blinking
-export LESS_TERMCAP_mb=$_omb_term_green
-export LESS_TERMCAP_md=$_omb_term_bold_green
-export LESS_TERMCAP_me=$_omb_term_reset
+# Adds the LESS_TERMCAP_* variables to the environment to color man pages.
+function colored() {
+  local -a environment
 
-# Standout Mode
-export LESS_TERMCAP_so=$_omb_term_olive
-export LESS_TERMCAP_se=$_omb_term_reset
+  environment+=( LESS_TERMCAP_mb=${_omb_term_red} )
+  environment+=( LESS_TERMCAP_md=${_omb_term_bold_red} )
+  environment+=( LESS_TERMCAP_me=${_omb_term_reset} )
+  environment+=( LESS_TERMCAP_so=${_omb_term_bold_yellow} )
+  environment+=( LESS_TERMCAP_se=${_omb_term_reset} )
+  environment+=( LESS_TERMCAP_us=${_omb_term_bold_green} )
+  environment+=( LESS_TERMCAP_ue=${_omb_term_reset} )
 
-# Underline
-export LESS_TERMCAP_us=$_omb_term_purple
-export LESS_TERMCAP_ue=$_omb_term_reset
+  # Prefer `less` whenever available, since we specifically configured
+  # environment for it.
+  environment+=( PAGER="${commands[less]:-$PAGER}" )
+  environment+=( GROFF_NO_SGR=1 )
 
-# Extra Styles
+  env "${environment[@]}" "$@"
+}
+
+# Wrapper for man to colorize the output.
+function man {
+  colored man "$@"
+}
+
+# Wrapper for dman to colorize the output.
+function dman {
+  colored dman "$@"
+}
+
+# Wrapper for debman to colorize the output.
+function debman {
+  colored debman "$@"
+}

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -26,16 +26,19 @@ function colored() {
 }
 
 # Wrapper for man to colorize the output.
+_omb_util_binary_exists man &&
 function man {
-  colored man "$@"
+  colored "$FUNCNAME" "$@"
 }
 
 # Wrapper for dman to colorize the output.
+_omb_util_binary_exists dman &&
 function dman {
   colored dman "$@"
 }
 
 # Wrapper for debman to colorize the output.
+_omb_util_binary_exists debman &&
 function debman {
   colored debman "$@"
 }

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -5,24 +5,22 @@
 # This plugin is based on the following Oh-My-Zsh plugin:
 # https://github.com/ohmyzsh/ohmyzsh/blob/6bc4c80c7db072a0d2d265eb3589bbe52e0d2737/plugins/colored-man-pages/colored-man-pages.plugin.zsh
 
-# Adds the LESS_TERMCAP_* variables to the environment to color man pages.
+# Adds the LESS_TERMCAP_* variables to color the man pages.
 function colored() {
-  local -a environment
-
-  environment+=( LESS_TERMCAP_mb=${_omb_term_red} )
-  environment+=( LESS_TERMCAP_md=${_omb_term_bold_red} )
-  environment+=( LESS_TERMCAP_me=${_omb_term_reset} )
-  environment+=( LESS_TERMCAP_so=${_omb_term_bold_yellow} )
-  environment+=( LESS_TERMCAP_se=${_omb_term_reset} )
-  environment+=( LESS_TERMCAP_us=${_omb_term_green} )
-  environment+=( LESS_TERMCAP_ue=${_omb_term_reset} )
+  local -x LESS_TERMCAP_mb=${_omb_term_green}
+  local -x LESS_TERMCAP_md=${_omb_term_bold_green}
+  local -x LESS_TERMCAP_me=${_omb_term_reset}
+  local -x LESS_TERMCAP_so=${_omb_term_bold_yellow}
+  local -x LESS_TERMCAP_se=${_omb_term_reset}
+  local -x LESS_TERMCAP_us=${_omb_term_purple}
+  local -x LESS_TERMCAP_ue=${_omb_term_reset}
 
   # Prefer `less` whenever available, since we specifically configured
   # environment for it.
-  environment+=( PAGER="${commands[less]:-$PAGER}" )
-  environment+=( GROFF_NO_SGR=1 )
+  local -x PAGER="${commands[less]:-$PAGER}"
+  local -x GROFF_NO_SGR=1
 
-  env "${environment[@]}" "$@"
+  command "$@"
 }
 
 # Wrapper for man to colorize the output.

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -2,7 +2,7 @@
 
 # Bold and Blinking
 export LESS_TERMCAP_mb=$_omb_term_green
-export LESS_TERMCAP_md=$_omb_term_bold$_omb_term_green
+export LESS_TERMCAP_md=$_omb_term_bold_green
 export LESS_TERMCAP_me=$_omb_term_reset
 
 # Standout Mode

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -14,11 +14,3 @@ export LESS_TERMCAP_us=$_omb_term_purple
 export LESS_TERMCAP_ue=$_omb_term_reset
 
 # Extra Styles
-if _omb_util_binary_exists tput; then
-  export LESS_TERMCAP_mr=$(tput rev 2>/dev/null || tput mr 2>/dev/null)
-  export LESS_TERMCAP_mh=$(tput dim 2>/dev/null || tput mh 2>/dev/null)
-  export LESS_TERMCAP_ZN=$(tput ssubm 2>/dev/null)
-  export LESS_TERMCAP_ZV=$(tput rsubm 2>/dev/null)
-  export LESS_TERMCAP_ZO=$(tput ssupm 2>/dev/null)
-  export LESS_TERMCAP_ZW=$(tput rsupm 2>/dev/null)
-fi

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -1,47 +1,24 @@
 #! bash oh-my-bash.module
 
-# Safety get the colors.
-if tput setaf 1 &> /dev/null; then
-  COLORED_MAN_PAGES_BLACK=$(tput setaf 0)
-  COLORED_MAN_PAGES_RED=$(tput setaf 1)
-  COLORED_MAN_PAGES_GREEN=$(tput setaf 2)
-  COLORED_MAN_PAGES_YELLOW=$(tput setaf 3)
-  COLORED_MAN_PAGES_BLUE=$(tput setaf 4)
-  COLORED_MAN_PAGES_MAGENTA=$(tput setaf 5)
-  COLORED_MAN_PAGES_CYAN=$(tput setaf 6)
-  COLORED_MAN_PAGES_WHITE=$(tput setaf 7)
-  COLORED_MAN_PAGES_BOLD=$(tput bold)
-  COLORED_MAN_PAGES_RESET=$(tput sgr0)
-
-  # Extra Styles
-  export LESS_TERMCAP_mr=$(tput rev) # Reverse
-  export LESS_TERMCAP_mh=$(tput dim) # Half Bright
-  export LESS_TERMCAP_ZN=$(tput ssubm) # Subscript
-  export LESS_TERMCAP_ZV=$(tput rsubm) # Reverse Superscript
-  export LESS_TERMCAP_ZO=$(tput ssupm) # Subscript
-  export LESS_TERMCAP_ZW=$(tput rsupm) # Reverse Superscript
-else
-  COLORED_MAN_PAGES_BLACK="\033[1;30m"
-  COLORED_MAN_PAGES_RED="\033[1;31m"
-  COLORED_MAN_PAGES_GREEN="\033[1;32m"
-  COLORED_MAN_PAGES_YELLOW="\033[1;33m"
-  COLORED_MAN_PAGES_BLUE="\033[1;34m"
-  COLORED_MAN_PAGES_MAGENTA="\033[1;35m"
-  COLORED_MAN_PAGES_CYAN="\033[1;36m"
-  COLORED_MAN_PAGES_WHITE="\033[1;37m"
-  COLORED_MAN_PAGES_BOLD=""
-  COLORED_MAN_PAGES_RESET="\033[m"
-fi
-
 # Bold and Blinking
-export LESS_TERMCAP_mb=$COLORED_MAN_PAGES_GREEN
-export LESS_TERMCAP_md=$COLORED_MAN_PAGES_BOLD$COLORED_MAN_PAGES_GREEN
-export LESS_TERMCAP_me=$COLORED_MAN_PAGES_RESET
+export LESS_TERMCAP_mb=$_omb_term_green
+export LESS_TERMCAP_md=$_omb_term_bold$_omb_term_green
+export LESS_TERMCAP_me=$_omb_term_reset
 
 # Standout Mode
-export LESS_TERMCAP_so=$COLORED_MAN_PAGES_YELLOW
-export LESS_TERMCAP_se=$COLORED_MAN_PAGES_RESET
+export LESS_TERMCAP_so=$_omb_term_olive
+export LESS_TERMCAP_se=$_omb_term_reset
 
 # Underline
-export LESS_TERMCAP_us=$COLORED_MAN_PAGES_MAGENTA
-export LESS_TERMCAP_ue=$COLORED_MAN_PAGES_RESET
+export LESS_TERMCAP_us=$_omb_term_purple
+export LESS_TERMCAP_ue=$_omb_term_reset
+
+# Extra Styles
+if _omb_util_binary_exists tput; then
+  export LESS_TERMCAP_mr=$(tput rev 2>/dev/null || tput mr 2>/dev/null)
+  export LESS_TERMCAP_mh=$(tput dim 2>/dev/null || tput mh 2>/dev/null)
+  export LESS_TERMCAP_ZN=$(tput ssubm 2>/dev/null)
+  export LESS_TERMCAP_ZV=$(tput rsubm 2>/dev/null)
+  export LESS_TERMCAP_ZO=$(tput ssupm 2>/dev/null)
+  export LESS_TERMCAP_ZW=$(tput rsupm 2>/dev/null)
+fi

--- a/plugins/colored-man-pages/colored-man-pages.plugin.sh
+++ b/plugins/colored-man-pages/colored-man-pages.plugin.sh
@@ -14,7 +14,7 @@ function colored() {
   environment+=( LESS_TERMCAP_me=${_omb_term_reset} )
   environment+=( LESS_TERMCAP_so=${_omb_term_bold_yellow} )
   environment+=( LESS_TERMCAP_se=${_omb_term_reset} )
-  environment+=( LESS_TERMCAP_us=${_omb_term_bold_green} )
+  environment+=( LESS_TERMCAP_us=${_omb_term_green} )
   environment+=( LESS_TERMCAP_ue=${_omb_term_reset} )
 
   # Prefer `less` whenever available, since we specifically configured


### PR DESCRIPTION
Inspired by the [`colored-man-pages`](https://github.com/ohmyzsh/ohmyzsh/tree/a72a26406ad3aa9a47c3f5227291bad23494bed0/plugins/colored-man-pages) zsh plugin.

This is likely not the best design, as I'm grabbing the specific colors. If there's a better method, feel free to let me know.


![Screenshot from 2024-09-30 16-53-12](https://github.com/user-attachments/assets/ab34ccae-b6ef-4b02-b3d0-0c09ff13f4c2)

