### PR TITLE
progress: Improve the Progress Plugin

### DIFF
--- a/plugins/progress/README.md
+++ b/plugins/progress/README.md
@@ -22,8 +22,8 @@ Bash.  The function handles printing of the progress bar.
 2. **Invoke `progress` Function:**
    - Within a shell function, call the `progress` function whenever you want to display the progress bar.
    - Pass two parameters to the `progress` function:
-     - `PARAM_PROGRESS`: The progress percentage (0-100) of the task.
-     - `PARAM_STATUS`: Optional. A status message to display alongside the progress bar.
+     - `value`: The progress percentage (0-100) of the task. Passing 0 will reset the progress bar status.
+     - `message`: Optional. A status message to display alongside the progress bar.
 
    ```bash
    # Example usage:

--- a/plugins/progress/progress.plugin.sh
+++ b/plugins/progress/progress.plugin.sh
@@ -4,7 +4,7 @@
 # Summary       : Show a progress bar GUI on terminal platform                 #
 # Support       : destro.nnt@gmail.com                                         #
 # Created date  : Aug 12,2014                                                  #
-# Latest Modified date : Aug 13,2014                                           #
+# Latest Modified date : Dec 19,2024                                           #
 #                                                                              #
 ################################################################################
 
@@ -20,76 +20,80 @@
 # Global variable to store progress value
 _omb_plugin_progress_value=0
 
+_omb_plugin_progress_clear_line=
+
 #
 # Description : delay executing script
 #
-function delay()
-{
-  sleep 0.2;
+function delay {
+  sleep 0.2
 }
 
 #
 # Description : print out executing progress
 #
-function progress()
-{
-  local value=$1;
-  local message=$2;
+function progress {
+  local value=$1
+  local message=$2
 
-  if [ -z $value ]; then
-    printf 'Usage: progress <value> [message]\n\n'
-    printf 'Options:\n'
-    printf '  value    The value for the progress bar. Use 0 to reset.\n'
-    printf '  message  The optional message to display next to the progress bar.\n'
+  if [[ ! $value ]]; then
+    _omb_util_print_lines \
+      'Usage: progress <value> [message]' \
+      '' \
+      'Options:' \
+      '  value    The value for the progress bar. Use 0 to reset.' \
+      '  message  The optional message to display next to the progress bar.'
     return 2
   fi
 
-  if [ $value -lt 0 ]; then
+  if ((value < 0)); then
     _omb_log_error "invalid value: value' (expect: 0-100)" >&2
     return 2
   fi
 
   # Reset the progress value
-  if [ $value -eq 0 ]; then
-    _omb_plugin_progress_value=0;
+  if ((value == 0)); then
+    _omb_plugin_progress_value=0
     return 0
   fi
 
   # Get a clear line escape sequence
-  local clear_line
-  clear_line=$(tput el 2>/dev/null || tput ce 2>/dev/null)
-  if [ -z $clear_line ]; then
-    clear_line=$'\e[K'
+  local clear_line=$_omb_plugin_progress_clear_line
+  if [[ ! $clear_line ]]; then
+    clear_line=$(tput el 2>/dev/null || tput ce 2>/dev/null)
+    if [[ ! $clear_line ]]; then
+      clear_line=$'\e[K'
+    fi
+    _omb_plugin_progress_clear_line=$clear_line
   fi
 
-  if [ $_omb_plugin_progress_value -le 0 -a $value -ge 0 ]  ; then printf "%s[............................] (0%%)  %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 5 -a $value -ge 5 ]  ; then printf "%s[#...........................] (5%%)  %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 10 -a $value -ge 10 ]; then printf "%s[##..........................] (10%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 15 -a $value -ge 15 ]; then printf "%s[###.........................] (15%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 20 -a $value -ge 20 ]; then printf "%s[####........................] (20%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 25 -a $value -ge 25 ]; then printf "%s[#####.......................] (25%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 30 -a $value -ge 30 ]; then printf "%s[######......................] (30%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 35 -a $value -ge 35 ]; then printf "%s[#######.....................] (35%%) %s\r" "$clear_line" "$message" ; delay; fi;
-
-  if [ $_omb_plugin_progress_value -le 40 -a $value -ge 40 ]; then printf "%s[########....................] (40%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 45 -a $value -ge 45 ]; then printf "%s[#########...................] (45%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 50 -a $value -ge 50 ]; then printf "%s[##########..................] (50%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 55 -a $value -ge 55 ]; then printf "%s[###########.................] (55%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 60 -a $value -ge 60 ]; then printf "%s[############................] (60%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 65 -a $value -ge 65 ]; then printf "%s[#############...............] (65%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 70 -a $value -ge 70 ]; then printf "%s[##############..............] (70%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 75 -a $value -ge 75 ]; then printf "%s[################............] (75%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 80 -a $value -ge 80 ]; then printf "%s[##################..........] (80%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 85 -a $value -ge 85 ]; then printf "%s[#####################.......] (85%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 90 -a $value -ge 90 ]; then printf "%s[########################....] (90%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 95 -a $value -ge 95 ]; then printf "%s[###########################.] (95%%) %s\r" "$clear_line" "$message" ; delay; fi;
-  if [ $_omb_plugin_progress_value -le 100 -a $value -ge 100 ]; then
+  if ((_omb_plugin_progress_value <=   0 && value >=   0)); then printf "%s[............................] (0%%)  %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=   5 && value >=   5)); then printf "%s[#...........................] (5%%)  %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  10 && value >=  10)); then printf "%s[##..........................] (10%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  15 && value >=  15)); then printf "%s[###.........................] (15%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  20 && value >=  20)); then printf "%s[####........................] (20%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  25 && value >=  25)); then printf "%s[#####.......................] (25%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  30 && value >=  30)); then printf "%s[######......................] (30%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  35 && value >=  35)); then printf "%s[#######.....................] (35%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  40 && value >=  40)); then printf "%s[########....................] (40%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  45 && value >=  45)); then printf "%s[#########...................] (45%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  50 && value >=  50)); then printf "%s[##########..................] (50%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  55 && value >=  55)); then printf "%s[###########.................] (55%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  60 && value >=  60)); then printf "%s[############................] (60%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  65 && value >=  65)); then printf "%s[#############...............] (65%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  70 && value >=  70)); then printf "%s[##############..............] (70%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  75 && value >=  75)); then printf "%s[################............] (75%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  80 && value >=  80)); then printf "%s[##################..........] (80%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  85 && value >=  85)); then printf "%s[#####################.......] (85%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  90 && value >=  90)); then printf "%s[########################....] (90%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <=  95 && value >=  95)); then printf "%s[###########################.] (95%%) %s\r" "$clear_line" "$message"; delay; fi
+  if ((_omb_plugin_progress_value <= 100 && value >= 100)); then
     # Display the finished progress bar, and then clear with a new line.
     printf "%s[############################] (100%%) %s\r" "$clear_line" "$message"
     delay
     printf 'Done!%s\n' "$clear_line"
     value=0
-  fi;
+  fi
 
-  _omb_plugin_progress_value=$value;
+  _omb_plugin_progress_value=$value
 }

--- a/plugins/progress/progress.plugin.sh
+++ b/plugins/progress/progress.plugin.sh
@@ -33,63 +33,63 @@ function delay()
 #
 function progress()
 {
-    local value=$1;
-    local message=$2;
+  local value=$1;
+  local message=$2;
 
-    if [ -z $value ]; then
-      printf 'Usage: progress <value> [message]\n\n'
-      printf 'Options:\n'
-      printf '  value    The value for the progress bar. Use 0 to reset.\n'
-      printf '  message  The optional message to display next to the progress bar.\n'
-      return 2
-    fi
+  if [ -z $value ]; then
+    printf 'Usage: progress <value> [message]\n\n'
+    printf 'Options:\n'
+    printf '  value    The value for the progress bar. Use 0 to reset.\n'
+    printf '  message  The optional message to display next to the progress bar.\n'
+    return 2
+  fi
 
-    if [ $value -lt 0 ]; then
-      _omb_log_error "invalid value: value' (expect: 0-100)" >&2
-      return 2
-    fi
+  if [ $value -lt 0 ]; then
+    _omb_log_error "invalid value: value' (expect: 0-100)" >&2
+    return 2
+  fi
 
-    # Reset the progress value
-    if [ $value -eq 0 ]; then
-      _omb_plugin_progress_value=0;
-      return 0
-    fi
+  # Reset the progress value
+  if [ $value -eq 0 ]; then
+    _omb_plugin_progress_value=0;
+    return 0
+  fi
 
-    # Get a clear line escape sequence
-    local clear_line
-    clear_line=$(tput el 2>/dev/null || tput ce 2>/dev/null)
-    if [ -z $clear_line ]; then
-      clear_line=$'\e[K'
-    fi
+  # Get a clear line escape sequence
+  local clear_line
+  clear_line=$(tput el 2>/dev/null || tput ce 2>/dev/null)
+  if [ -z $clear_line ]; then
+    clear_line=$'\e[K'
+  fi
 
-    if [ $_omb_plugin_progress_value -le 0 -a $value -ge 0 ]  ; then printf "%s[....................] (0%%)  %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 5 -a $value -ge 5 ]  ; then printf "%s[#...................] (5%%)  %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 10 -a $value -ge 10 ]; then printf "%s[##..................] (10%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 15 -a $value -ge 15 ]; then printf "%s[###.................] (15%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 20 -a $value -ge 20 ]; then printf "%s[####................] (20%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 25 -a $value -ge 25 ]; then printf "%s[#####...............] (25%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 30 -a $value -ge 30 ]; then printf "%s[######..............] (30%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 35 -a $value -ge 35 ]; then printf "%s[#######.............] (35%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 0 -a $value -ge 0 ]  ; then printf "%s[............................] (0%%)  %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 5 -a $value -ge 5 ]  ; then printf "%s[#...........................] (5%%)  %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 10 -a $value -ge 10 ]; then printf "%s[##..........................] (10%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 15 -a $value -ge 15 ]; then printf "%s[###.........................] (15%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 20 -a $value -ge 20 ]; then printf "%s[####........................] (20%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 25 -a $value -ge 25 ]; then printf "%s[#####.......................] (25%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 30 -a $value -ge 30 ]; then printf "%s[######......................] (30%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 35 -a $value -ge 35 ]; then printf "%s[#######.....................] (35%%) %s\r" "$clear_line" "$message" ; delay; fi;
 
-    if [ $_omb_plugin_progress_value -le 40 -a $value -ge 40 ]; then printf "%s[########............] (40%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 45 -a $value -ge 45 ]; then printf "%s[#########...........] (45%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 50 -a $value -ge 50 ]; then printf "%s[##########..........] (50%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 55 -a $value -ge 55 ]; then printf "%s[###########.........] (55%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 60 -a $value -ge 60 ]; then printf "%s[############........] (60%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 65 -a $value -ge 65 ]; then printf "%s[#############.......] (65%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 70 -a $value -ge 70 ]; then printf "%s[##############......] (70%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 75 -a $value -ge 75 ]; then printf "%s[###############.....] (75%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 80 -a $value -ge 80 ]; then printf "%s[################....] (80%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 85 -a $value -ge 85 ]; then printf "%s[#################...] (85%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 90 -a $value -ge 90 ]; then printf "%s[##################..] (90%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 95 -a $value -ge 95 ]; then printf "%s[###################.] (95%%) %s\r" "$clear_line" "$message" ; delay; fi;
-    if [ $_omb_plugin_progress_value -le 100 -a $value -ge 100 ]; then
-      # Display the finished progress bar, and then clear with a new line.
-      printf "%s[####################] (100%%) %s\r" "$clear_line" "$message"
-      delay
-      printf "%s\n" "$clear_line"
-      value=0
-    fi;
+  if [ $_omb_plugin_progress_value -le 40 -a $value -ge 40 ]; then printf "%s[########....................] (40%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 45 -a $value -ge 45 ]; then printf "%s[#########...................] (45%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 50 -a $value -ge 50 ]; then printf "%s[##########..................] (50%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 55 -a $value -ge 55 ]; then printf "%s[###########.................] (55%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 60 -a $value -ge 60 ]; then printf "%s[############................] (60%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 65 -a $value -ge 65 ]; then printf "%s[#############...............] (65%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 70 -a $value -ge 70 ]; then printf "%s[##############..............] (70%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 75 -a $value -ge 75 ]; then printf "%s[################............] (75%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 80 -a $value -ge 80 ]; then printf "%s[##################..........] (80%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 85 -a $value -ge 85 ]; then printf "%s[#####################.......] (85%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 90 -a $value -ge 90 ]; then printf "%s[########################....] (90%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 95 -a $value -ge 95 ]; then printf "%s[###########################.] (95%%) %s\r" "$clear_line" "$message" ; delay; fi;
+  if [ $_omb_plugin_progress_value -le 100 -a $value -ge 100 ]; then
+    # Display the finished progress bar, and then clear with a new line.
+    printf "%s[############################] (100%%) %s\r" "$clear_line" "$message"
+    delay
+    printf 'Done!%s\n' "$clear_line"
+    value=0
+  fi;
 
-    _omb_plugin_progress_value=$value;
+  _omb_plugin_progress_value=$value;
 }

--- a/plugins/progress/progress.plugin.sh
+++ b/plugins/progress/progress.plugin.sh
@@ -17,6 +17,8 @@
 
 ################################################################################
 
+# Global variable to store progress value
+_omb_plugin_progress_value=0
 
 #
 # Description : delay executing script
@@ -29,32 +31,65 @@ function delay()
 #
 # Description : print out executing progress
 #
-CURRENT_PROGRESS=0
 function progress()
 {
-  PARAM_PROGRESS=$1;
-  PARAM_STATUS=$2;
+    local value=$1;
+    local message=$2;
 
-  if [ $CURRENT_PROGRESS -le 0 -a $PARAM_PROGRESS -ge 0 ]  ; then printf "[..........................] (0%%)  %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 5 -a $PARAM_PROGRESS -ge 5 ]  ; then printf "[#.........................] (5%%)  %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 10 -a $PARAM_PROGRESS -ge 10 ]; then printf "[##........................] (10%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 15 -a $PARAM_PROGRESS -ge 15 ]; then printf "[###.......................] (15%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 20 -a $PARAM_PROGRESS -ge 20 ]; then printf "[####......................] (20%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 25 -a $PARAM_PROGRESS -ge 25 ]; then printf "[#####.....................] (25%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 30 -a $PARAM_PROGRESS -ge 30 ]; then printf "[######....................] (30%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 35 -a $PARAM_PROGRESS -ge 35 ]; then printf "[#######...................] (35%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 40 -a $PARAM_PROGRESS -ge 40 ]; then printf "[########..................] (40%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 45 -a $PARAM_PROGRESS -ge 45 ]; then printf "[#########.................] (45%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 50 -a $PARAM_PROGRESS -ge 50 ]; then printf "[##########................] (50%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 55 -a $PARAM_PROGRESS -ge 55 ]; then printf "[###########...............] (55%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 60 -a $PARAM_PROGRESS -ge 60 ]; then printf "[############..............] (60%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 65 -a $PARAM_PROGRESS -ge 65 ]; then printf "[#############.............] (65%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 70 -a $PARAM_PROGRESS -ge 70 ]; then printf "[###############...........] (70%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 75 -a $PARAM_PROGRESS -ge 75 ]; then printf "[#################.........] (75%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 80 -a $PARAM_PROGRESS -ge 80 ]; then printf "[####################......] (80%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 85 -a $PARAM_PROGRESS -ge 85 ]; then printf "[#######################...] (90%%) %s \r" "$PARAM_PHASE" ; delay; fi;
-  if [ $CURRENT_PROGRESS -le 90 -a $PARAM_PROGRESS -ge 90 ]; then printf "[##########################] (100%%) %s \r" "$PARAM_PHASE"; delay; fi;
-  if [ $CURRENT_PROGRESS -le 100 -a $PARAM_PROGRESS -ge 100 ];then printf 'Done!                                            \n' ; delay; fi;
+    if [ -z $value ]; then
+      printf 'Usage: progress <value> [message]\n\n'
+      printf 'Options:\n'
+      printf '  value    The value for the progress bar. Use 0 to reset.\n'
+      printf '  message  The optional message to display next to the progress bar.\n'
+      return 2
+    fi
 
-  CURRENT_PROGRESS=$PARAM_PROGRESS;
+    if [ $value -lt 0 ]; then
+      _omb_log_error "invalid value: value' (expect: 0-100)" >&2
+      return 2
+    fi
+
+    # Reset the progress value
+    if [ $value -eq 0 ]; then
+      _omb_plugin_progress_value=0;
+      return 0
+    fi
+
+    # Get a clear line escape sequence
+    local clear_line
+    clear_line=$(tput el 2>/dev/null || tput ce 2>/dev/null)
+    if [ -z $clear_line ]; then
+      clear_line=$'\e[K'
+    fi
+
+    if [ $_omb_plugin_progress_value -le 0 -a $value -ge 0 ]  ; then printf "%s[....................] (0%%)  %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 5 -a $value -ge 5 ]  ; then printf "%s[#...................] (5%%)  %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 10 -a $value -ge 10 ]; then printf "%s[##..................] (10%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 15 -a $value -ge 15 ]; then printf "%s[###.................] (15%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 20 -a $value -ge 20 ]; then printf "%s[####................] (20%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 25 -a $value -ge 25 ]; then printf "%s[#####...............] (25%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 30 -a $value -ge 30 ]; then printf "%s[######..............] (30%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 35 -a $value -ge 35 ]; then printf "%s[#######.............] (35%%) %s\r" "$clear_line" "$message" ; delay; fi;
+
+    if [ $_omb_plugin_progress_value -le 40 -a $value -ge 40 ]; then printf "%s[########............] (40%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 45 -a $value -ge 45 ]; then printf "%s[#########...........] (45%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 50 -a $value -ge 50 ]; then printf "%s[##########..........] (50%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 55 -a $value -ge 55 ]; then printf "%s[###########.........] (55%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 60 -a $value -ge 60 ]; then printf "%s[############........] (60%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 65 -a $value -ge 65 ]; then printf "%s[#############.......] (65%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 70 -a $value -ge 70 ]; then printf "%s[##############......] (70%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 75 -a $value -ge 75 ]; then printf "%s[###############.....] (75%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 80 -a $value -ge 80 ]; then printf "%s[################....] (80%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 85 -a $value -ge 85 ]; then printf "%s[#################...] (85%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 90 -a $value -ge 90 ]; then printf "%s[##################..] (90%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 95 -a $value -ge 95 ]; then printf "%s[###################.] (95%%) %s\r" "$clear_line" "$message" ; delay; fi;
+    if [ $_omb_plugin_progress_value -le 100 -a $value -ge 100 ]; then
+      # Display the finished progress bar, and then clear with a new line.
+      printf "%s[####################] (100%%) %s\r" "$clear_line" "$message"
+      delay
+      printf "%s\n" "$clear_line"
+      value=0
+    fi;
+
+    _omb_plugin_progress_value=$value;
 }


### PR DESCRIPTION
This change improves the progress plugin by...
- Allows reseting the progress bar to allow running another progress bar after the first one is done
- Replaces the message whitespace so that there's no overlap in messages
- Scopes the variables within the function
- Renames the global variable so that it's namespaced a bit

Here's a good way to test it...
``` bash
progress 0 "Doing something cool!" && progress 40 "Hello?" && progress 60 "Almost done" && progress 100 "Close" && delay
```