### PR TITLE
grep - fix option availability check.

### DIFF
--- a/lib/grep.sh
+++ b/lib/grep.sh
@@ -2,7 +2,7 @@
 
 # is x grep argument available?
 function _omb_grep_flag_available {
-  : | grep "$1" "" >/dev/null 2>&1
+  grep "$1" --help >/dev/null 2>&1
 }
 
 _omb_grep_options=()

--- a/lib/grep.sh
+++ b/lib/grep.sh
@@ -2,7 +2,7 @@
 
 # is x grep argument available?
 function _omb_grep_flag_available {
-  grep "$1" --help >/dev/null 2>&1
+  echo | grep "$1" "" >/dev/null 2>&1
 }
 
 _omb_grep_options=()


### PR DESCRIPTION
# Description
Checks if the desired _grep_ option is available, properly.

# Cause
Executing `: | grep "$1" "" >/dev/null 2>&1` **always** return `false` on _bash_ `5.2.15(1)-release (x86_64-pc-linux-gnu)` @ _linux_ `6.1.0-25-amd64`.

It causes problems like:
- no color for matches
- including undesired directories