### PR TITLE
Fix powerline multiline last status check

### DIFF
--- a/themes/powerline-multiline/powerline-multiline.base.sh
+++ b/themes/powerline-multiline/powerline-multiline.base.sh
@@ -3,7 +3,7 @@
 source "$OSH/themes/powerline/powerline.base.sh"
 
 function __powerline_last_status_prompt {
-  (($1 != 0)) && _omb_util_print "$(set_color $LAST_STATUS_THEME_PROMPT_COLOR -) $1 $_omb_prompt_normal"
+  [[ "$1" -ne 0 ]] && _omb_util_print "$(set_color $LAST_STATUS_THEME_PROMPT_COLOR -) $1 $_omb_prompt_normal"
 }
 
 function __powerline_right_segment {


### PR DESCRIPTION
Using the same check syntax used in `powerline.base.sh`, in same function (`__powerline_last_status_prompt`) at line [173](https://github.com/ohmybash/oh-my-bash/blob/5ce9fadcde08c5751c6da008ae3a1d4053516caf/themes/powerline/powerline.base.sh#L173)