### PR TITLE
Add unicode support for brainy prompt

### DIFF
--- a/themes/brainy/brainy.theme.sh
+++ b/themes/brainy/brainy.theme.sh
@@ -172,7 +172,7 @@ function ___brainy_prompt_exitcode {
 function ___brainy_prompt_char {
   local color=$_omb_prompt_bold_white
   local prompt_char="${__BRAINY_PROMPT_CHAR_PS1}"
-  printf "%s|%s" "$color" "${prompt_char}"
+  printf "%s|${prompt_char}" "$color" 
 }
 
 #########


### PR DESCRIPTION
The brainy terminal prompt could not process unicode characters correctly. Unicode characters get processed as a string literal due to the printf function. 

added the following to .bashrc:
`export THEME_PROMPT_CHAR_PS1="\u03bb -> "`