### PR TITLE
feat: add spack environment in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ Some themes turn on it by default.  If you would like to turn it off, you may di
 OMB_PROMPT_SHOW_PYTHON_VENV=false
 ```
 
+#### Enable/disable Spack environment information
+
+To enable the Spack environment information in the prompt, please set the
+following shell variable in `~/.bashrc`:
+
+```bash
+OMB_PROMPT_SHOW_SPACK_ENV=true
+```
+
+If the theme supports it, the information of the currently active Spack
+environment will be shown.  If the theme you use does not support the Spack
+environment information, a pull request to add it is welcome.  See the `font`
+theme as an example implementation of including the Spack environment.
+
 #### Disable internal uses of `sudo`
 
 Some plugins of oh-my-bash internally use `sudo` when it is necessary.  However, this might clutter with the `sudo` log.  To disable the use of `sudo` by oh-my-bash, `OMB_USE_SUDO` can be set to `false` in `~/.bashrc`.

--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -80,6 +80,7 @@ CHRUBY_THEME_PROMPT_SUFFIX='|'
 # OMB_PROMPT_CONDAENV_USE_BASENAME=true
 # OMB_PROMPT_PYTHON_VERSION_FORMAT=' |%s|'
 # OMB_PROMPT_SHOW_PYTHON_VENV=true
+OMB_PROMPT_SPACK_ENV_FORMAT='[%s] '
 
 # deprecate
 VIRTUALENV_THEME_PROMPT_PREFIX=' |'
@@ -536,6 +537,16 @@ function _omb_prompt_get_python_env {
   _omb_prompt_get_python_version
   python_env=$virtualenv$condaenv$python_version
   [[ $python_env ]]
+}
+
+## @fn _omb_prompt_get_spack_env
+##   @var[out] spack_env
+##   @exit
+function _omb_prompt_get_spack_env {
+  spack_env=
+  [[ ${OMB_PROMPT_SHOW_SPACK_ENV-} == true ]] || return 1
+  [[ ${SPACK_ENV-} ]] || return 1
+  _omb_prompt_format spack_env "$(basename "$SPACK_ENV")" OMB_PROMPT_SPACK_ENV
 }
 
 _omb_util_defun_print _omb_prompt_{print,get}_virtualenv virtualenv

--- a/templates/bashrc.osh-template
+++ b/templates/bashrc.osh-template
@@ -79,6 +79,10 @@ OMB_USE_SUDO=true
 # OMB_PROMPT_SHOW_PYTHON_VENV=true  # enable
 # OMB_PROMPT_SHOW_PYTHON_VENV=false # disable
 
+# To enable/disable Spack environment information
+# OMB_PROMPT_SHOW_SPACK_ENV=true  # enable
+# OMB_PROMPT_SHOW_SPACK_ENV=false # disable
+
 # Which completions would you like to load? (completions can be found in ~/.oh-my-bash/completions/*)
 # Custom completions may be added to ~/.oh-my-bash/custom/completions/
 # Example format: completions=(ssh git bundler gem pip pip3)

--- a/themes/font/font.theme.sh
+++ b/themes/font/font.theme.sh
@@ -44,6 +44,8 @@ function _omb_theme_PROMPT_COMMAND() {
     local hostname="${_omb_prompt_bold_gray}\u@\h"
     local python_venv; _omb_prompt_get_python_venv
     python_venv=$_omb_prompt_white$python_venv
+    local spack_env; _omb_prompt_get_spack_env
+    spack_env=$_omb_prompt_white$spack_env
 
     # Set return status color
     if [[ ${RC} == 0 ]]; then
@@ -55,7 +57,7 @@ function _omb_theme_PROMPT_COMMAND() {
     # Append new history lines to history file
     history -a
 
-    PS1="$(clock_prompt)$python_venv${hostname} ${_omb_prompt_bold_teal}\W $(scm_prompt_char_info)${ret_status}→ ${_omb_prompt_normal}"
+    PS1="$(clock_prompt)$spack_env$python_venv${hostname} ${_omb_prompt_bold_teal}\W $(scm_prompt_char_info)${ret_status}→ ${_omb_prompt_normal}"
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND


### PR DESCRIPTION
[Spack](https://spack.io/) is a packaging manager allowing to create an environment (like Python virtual environment).
I added a function allowing the display of the spack environment name in the prompt.

![image](https://github.com/user-attachments/assets/e2458f10-7ab9-410a-b2c7-8d05cd093139)

The theme `font` was also updated with this modification (see the screenshot above - I have modified the colors on my local installation, but not on this version !)

Note that if Spack is not installed, this should not cause any error (at least it did not on my local tests)

I found issue #259 about this, but no actual solution was proposed (actually, I think he just did what I have done on his local installation :wink:)

I tried to follow the coding guidelines, if there is something that need to be improved, just tell me :)