### PR TITLE
fix(plugins/nvm): Correctly handle `.nvmrc` in a parent directory.

### DIFF
--- a/plugins/nvm/nvm.plugin.sh
+++ b/plugins/nvm/nvm.plugin.sh
@@ -54,7 +54,7 @@ if _omb_util_command_exists nvm && [[ ${OMB_PLUGIN_NVM_AUTO_USE-} == true ]]; th
   }
 
   function _omb_plugin_nvm_cd {
-    cd "$@" || return "$?"
+    command cd "$@" || return "$?"
     local nvm_path=$(_omb_plugin_nvm_find_up .nvmrc)
 
     # If there are no .nvmrc file, use the default nvm version
@@ -84,7 +84,7 @@ if _omb_util_command_exists nvm && [[ ${OMB_PLUGIN_NVM_AUTO_USE-} == true ]]; th
       # multiple matching versions, take the latest one.  Remove the `->` and
       # `*` characters and spaces.  `locally_resolved_nvm_version` will be
       # `N/A` if no local versions are found.
-      locally_resolved_nvm_version=$(nvm ls --no-colors "$nvm_version" | sed -n '${s/->//g;s/[*[:space:]]//g;p;}')
+      locally_resolved_nvm_version=$(nvm ls --no-colors "$nvm_version" | command sed -n '${s/->//g;s/[*[:space:]]//g;p;}')
 
       # If it is not already installed, install it
       if [[ $locally_resolved_nvm_version == N/A ]]; then

--- a/plugins/nvm/nvm.plugin.sh
+++ b/plugins/nvm/nvm.plugin.sh
@@ -16,8 +16,12 @@ fi
 #------------------------------------------------------------------------------
 # Optional .nvmrc autoload
 #
-# This part is originally from the official nvm documentation
-# (README.md).  Here is the license of the original project:
+# This part is originally from the official nvm documentation (README.md).  The
+# current version is based on the following lines:
+#
+#   https://github.com/nvm-sh/nvm/blob/99352a64d25ce27d49ff6a449663ce3d7c12e5b5/README.md?plain=1#L686-L726
+#
+# Here is the license of the original project:
 #
 # The MIT License (MIT)
 #

--- a/plugins/nvm/nvm.plugin.sh
+++ b/plugins/nvm/nvm.plugin.sh
@@ -84,7 +84,7 @@ if _omb_util_command_exists nvm && [[ ${OMB_PLUGIN_NVM_AUTO_USE-} == true ]]; th
       # multiple matching versions, take the latest one.  Remove the `->` and
       # `*` characters and spaces.  `locally_resolved_nvm_version` will be
       # `N/A` if no local versions are found.
-      locally_resolved_nvm_version=$(nvm ls --no-colors $(<"./.nvmrc") | sed -n '${s/->//g;s/[*[:space:]]//g;p;}')
+      locally_resolved_nvm_version=$(nvm ls --no-colors "$nvm_version" | sed -n '${s/->//g;s/[*[:space:]]//g;p;}')
 
       # If it is not already installed, install it
       if [[ $locally_resolved_nvm_version == N/A ]]; then

--- a/plugins/nvm/nvm.plugin.sh
+++ b/plugins/nvm/nvm.plugin.sh
@@ -28,24 +28,22 @@ fi
 # Copyright (c) 2010 Tim Caswell
 # Copyright (c) 2014 Jordan Harband
 #
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
 if _omb_util_command_exists nvm && [[ ${OMB_PLUGIN_NVM_AUTO_USE-} == true ]]; then


### PR DESCRIPTION
When checking the version in the resolved `.nvmrc` file found, the
change made in d2163a6 tried to read the file a second time, but did not
use the resolved `$nvm_path` but rather tried to simply read it from the
current directory. This fails if the file was resolved to a parent
directory.

This change updates the code to reuse the version value which was read
from the file two lines prior.