### PR TITLE
Ensure rmdir doen't fail / return non zero

### DIFF
--- a/tools/check_for_upgrade.sh
+++ b/tools/check_for_upgrade.sh
@@ -57,7 +57,7 @@ type -P git &>/dev/null || return 0
 
 if command mkdir -p "$OSH/log/update.lock" 2>/dev/null; then
   _omb_upgrade_check
-  command rmdir "$OSH"/log/update.lock
+  command rmdir "$OSH"/log/update.lock || :
 else
   printf '%s\n' \
     'oh-my-bash/check_for_upgrade: Failed to get a lock.  Please make sure that no' \


### PR DESCRIPTION
This is meant to fix this error:

```sh
         __                          __               __
  ____  / /_     ____ ___  __  __   / /_  ____ ______/ /_
 / __ \/ __ \   / __ `__ \/ / / /  / __ \/ __ `/ ___/ __ \
/ /_/ / / / /  / / / / / / /_/ /  / /_/ / /_/ (__  ) / / /
\____/_/ /_/  /_/ /_/ /_/\__, /  /_.___/\__,_/____/_/ /_/
                        /____/
Hooray! Oh My Bash has been updated and/or is at the current version.
To keep up on the latest news and updates, follow us on GitHub: https://github.com/ohmybash/oh-my-bash
rmdir: failed to remove '/home/esender/.oh-my-bash/log/update.lock': No such file or directory
```

That `rmdir` failure can be avoided with `command rmdir "$OSH"/log/update.lock || true`

```c
01:52:00 esender@machine .oh-my-bash ±|rmdir-no-fail|→ command rmdir xxx
rmdir: failed to remove 'xxx': No such file or directory
01:52:02 esender@machine .oh-my-bash ±|rmdir-no-fail|→ echo $?
1 # <--- Bad!
```
```c
01:52:04 esender@machine .oh-my-bash ±|rmdir-no-fail|→ command rmdir xxx || :
rmdir: failed to remove 'xxx': No such file or directory
01:52:14 esender@machine .oh-my-bash ±|rmdir-no-fail|→ echo $?
0 # <--- Not Bad!
```