### PR TITLE
feat(lib/omb-prompt-base): Add support for distrobox

### DIFF
--- a/lib/omb-prompt-base.sh
+++ b/lib/omb-prompt-base.sh
@@ -81,6 +81,7 @@ CHRUBY_THEME_PROMPT_SUFFIX='|'
 # OMB_PROMPT_PYTHON_VERSION_FORMAT=' |%s|'
 # OMB_PROMPT_SHOW_PYTHON_VENV=true
 OMB_PROMPT_SPACK_ENV_FORMAT='[%s] '
+OMB_PROMPT_DISTROBOX_FORMAT='[📦%s] '
 
 # deprecate
 VIRTUALENV_THEME_PROMPT_PREFIX=' |'
@@ -395,6 +396,17 @@ function hg_prompt_vars {
   else
     SCM_CHANGE=$(command hg summary 2> /dev/null | grep parent: | awk '{print $2}')
   fi
+}
+
+## @fn _omb_prompt_get_distrobox_container
+##   @var[out] distrobox_container
+##   @exit
+function _omb_prompt_get_distrobox_container {
+  distrobox_container=
+  [[ ${CONTAINER_ID-} ]] || return 1
+  distrobox_container=${CONTAINER_ID}
+  _omb_prompt_format distrobox_container "$distrobox_container" OMB_PROMPT_DISTROBOX:DISTROBOX_THEME_PROMPT
+  [[ $distrobox_container ]]
 }
 
 ## @fn _omb_prompt_get_rbfu

--- a/themes/font/font.theme.sh
+++ b/themes/font/font.theme.sh
@@ -46,6 +46,8 @@ function _omb_theme_PROMPT_COMMAND() {
     python_venv=$_omb_prompt_white$python_venv
     local spack_env; _omb_prompt_get_spack_env
     spack_env=$_omb_prompt_white$spack_env
+    local distrobox_container; _omb_prompt_get_distrobox_container
+    distrobox_container=$_omb_prompt_yellow$distrobox_container
 
     # Set return status color
     if [[ ${RC} == 0 ]]; then
@@ -57,7 +59,7 @@ function _omb_theme_PROMPT_COMMAND() {
     # Append new history lines to history file
     history -a
 
-    PS1="$(clock_prompt)$spack_env$python_venv${hostname} ${_omb_prompt_bold_teal}\W $(scm_prompt_char_info)${ret_status}→ ${_omb_prompt_normal}"
+    PS1="$(clock_prompt)$distrobox_container$spack_env$python_venv${hostname} ${_omb_prompt_bold_teal}\W $(scm_prompt_char_info)${ret_status}→ ${_omb_prompt_normal}"
 }
 
 _omb_util_add_prompt_command _omb_theme_PROMPT_COMMAND


### PR DESCRIPTION
[Distrobox](https://distrobox.it/) is "a container wrapping layer that allows the user to install containerised versions of Linux that are different to the host while providing tight integration with the host allowing the use of binaries designed for one distribution to run on another [(Arch wiki)](https://wiki.archlinux.org/title/Distrobox)".

This PR implements the basic function to get distrobox container name, and modified the default `font` theme to add distrobox info field.

![Screenshot_20250512_160909](https://github.com/user-attachments/assets/78249de5-60a7-4eb3-a307-c7b832995f80)
