### PR TITLE
Add wake plugin (WoL wrapper with MAC + broadcast)

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -55,6 +55,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | tmux-autoattach   | Plugin related to session management in the tmux terminal multiplexer.                                                      |
 | vagrant           | Tool for creating and managing virtual development environments.                                                            |
 | virtualenvwrapper | A set of extensions to the virtualenv tool.                                                                                 |
+| wake              | This plugin provides a wrapper around the "wakeonlan" tool.                                                                 |
 | xterm             | Terminal emulator for X Window systems providing a graphical user interface for accessing the command line.                 |
-| zellij-autoattach | Plugin related to session management in the zellij terminal multiplexer.                                                      |
+| zellij-autoattach | Plugin related to session management in the zellij terminal multiplexer.                                                    |
 | zoxide            | Utility for quickly navigating the filesystem based on visited directory history.                                           |

--- a/plugins/wake/README.md
+++ b/plugins/wake/README.md
@@ -1,0 +1,57 @@
+# wakeonlan
+
+This plugin provides a wrapper around the "wakeonlan" tool available from most
+distributions' package repositories, or from [the following website](https://github.com/jpoliv/wakeonlan).
+
+To use it, add `wake` to the plugins array in your bashrc file:
+
+```bash
+plugins=(... wake)
+```
+
+## Usage
+
+In order to use this wrapper, create the `~/.wakeonlan` directory, and place in
+that directory one file for each device you would like to be able to wake. Give
+the file a name that describes the device, such as its hostname. Each file
+should contain a line with the mac address of the target device and the network
+broadcast address.
+
+For instance, there might be a file `~/.wakeonlan/server` with the following
+contents:
+
+```
+00:11:22:33:44:55:66 192.168.0.255
+```
+
+To wake that device, use the following command:
+
+```console
+wake server
+```
+
+The available device names will be autocompleted, so:
+
+```console
+wake <tab>
+```
+
+...will suggest "server", along with any other configuration files that were
+placed in the `~/.wakeonlan` directory.
+
+You can also just type `wake` to list show usage and available devices:
+```
+Usage: wake <device>
+Available devices: server 
+```
+
+For more information regarding the configuration file format, check the
+wakeonlan man page. If your distirbution does not offer wakeonlan package just install it manually from the GitHub, here are the steps:
+
+```bash
+curl -RLOJ https://github.com/jpoliv/wakeonlan/raw/refs/heads/master/wakeonlan
+chmod a+x wakeonlan
+sudo install -o root -g root -m 755 wakeonlan /usr/local/bin/wakeonlan
+rm wakeonlan
+```
+Enjoy!

--- a/plugins/wake/wake.plugin.sh
+++ b/plugins/wake/wake.plugin.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# oh-my-bash.module: wake-on-lan wrapper + autocompletion
+# wake.plugin.sh
+# Author: hoek from 0ut3r.space
+# Based on oh-my-zsh wake plugin
+
+function wake() {
+  local cfgdir="$HOME/.wakeonlan"
+  local cfgfile="$cfgdir/$1"
+
+  if [[ -z "$1" || ! -f "$cfgfile" ]]; then
+    echo "Usage: wake <device>"
+    echo "Available devices: $(ls "$cfgdir" | tr '\n' ' ')"
+    return 1
+  fi
+
+  if ! command -v wakeonlan >/dev/null; then
+    echo "ERROR: 'wakeonlan' not found. Install it (https://github.com/jpoliv/wakeonlan)." >&2
+    return 1
+  fi
+
+  # Read the two fields: MAC and broadcast-IP
+  local mac bcast
+  read -r mac bcast < "$cfgfile"
+
+  # Send magic-packet to the given broadcast address
+  wakeonlan -i "$bcast" "$mac"
+}
+
+# autocomplete device names from ~/.wakeonlan
+_wake_completion() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local cfgdir="$HOME/.wakeonlan"
+  [[ -d "$cfgdir" ]] || return 0
+  COMPREPLY=( $(compgen -W "$(ls "$cfgdir")" -- "$cur") )
+}
+complete -F _wake_completion wake


### PR DESCRIPTION
Add a new wake plugin to Oh My Bash for easy Wake-on-LAN. The plugin:
- Reads a MAC address and broadcast IP from ~/.wakeonlan/<device>
- Sends the magic packet via wakeonlan -i <broadcast> <MAC>
- Provides Bash autocompletion of device names
- This lets users simply run wake <device> to power on machines on their LAN.