### PR TITLE
Fixed _omb_cd_dirstack[0]: unbound variable. Fixes #716.

### DIFF
--- a/lib/directories.sh
+++ b/lib/directories.sh
@@ -32,7 +32,7 @@ function _omb_directories_cd {
     _omb_cd_dirstack=("${DIRSTACK[@]/#~/$HOME}")
     OLDPWD=$oldpwd
   else
-    [[ ${_omb_cd_dirstack[0]} == "$PWD" ]] ||
+    [[ ${_omb_cd_dirstack[0]-} == "$PWD" ]] ||
       _omb_cd_dirstack=("$PWD" "${_omb_cd_dirstack[@]}")
     builtin cd "$@" &&
       _omb_cd_dirstack=("$PWD" "${_omb_cd_dirstack[@]}")


### PR DESCRIPTION
### **User description**
Fixes #716


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed unbound variable error in directory stack handling

- Added parameter expansion with default value to prevent bash error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Array Access"] -- "Add Default Value" --> B["Safe Parameter Expansion"]
  B -- "Prevents" --> C["Unbound Variable Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>directories.sh</strong><dd><code>Fix unbound variable in directory stack array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/directories.sh

<ul><li>Added parameter expansion with default value to <code>_omb_cd_dirstack[0]</code><br> <li> Changed <code>${_omb_cd_dirstack[0]}</code> to <code>${_omb_cd_dirstack[0]-}</code><br> <li> Prevents unbound variable error when array is empty</ul>


</details>


  </td>
  <td><a href="https://github.com/ohmybash/oh-my-bash/pull/717/files#diff-517ccb8f3b4967afc802a3f3c42e5ad4576b2d33bcc95db099246420cbb216bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

