### PR TITLE
Fix prompt color reset in primer theme

### DIFF
--- a/themes/primer/primer.theme.sh
+++ b/themes/primer/primer.theme.sh
@@ -2,7 +2,7 @@
 
 # based of the candy theme, but minimized by odbol
 function _omb_theme_PROMPT_COMMAND() {
-    PS1="$(clock_prompt) ${_omb_prompt_reset_color}${_omb_prompt_white}\w${_omb_prompt_reset_color}$(scm_prompt_info)${_omb_prompt_navy} →${_omb_prompt_bold_navy} ${_omb_prompt_reset_color} ";
+    PS1="$(clock_prompt) ${_omb_prompt_reset_color}${_omb_prompt_white}\w${_omb_prompt_reset_color}$(scm_prompt_info)${_omb_prompt_navy} →${_omb_prompt_bold_navy} ${_omb_prompt_reset_color}${_omb_prompt_normal} ";
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$_omb_prompt_navy"}


### PR DESCRIPTION
### **User description**
The "primer" theme does not correctly reset the bash prompt to normal mode, the creator probably missed the variable and no one noticed.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `${_omb_prompt_normal}` variable to prompt reset

- Ensures bash prompt correctly returns to normal mode

- Fixes incomplete color reset in primer theme


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Primer Theme Prompt"] -->|Missing normal reset| B["Incomplete color reset"]
  A -->|Add _omb_prompt_normal| C["Correct prompt behavior"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>primer.theme.sh</strong><dd><code>Add missing prompt normal reset variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/primer/primer.theme.sh

<ul><li>Added missing <code>${_omb_prompt_normal}</code> variable to the PS1 prompt string<br> <li> Placed after <code>${_omb_prompt_reset_color}</code> to properly reset prompt to <br>normal mode<br> <li> Fixes incomplete color reset that was preventing proper prompt display</ul>


</details>


  </td>
  <td><a href="https://github.com/ohmybash/oh-my-bash/pull/723/files#diff-f28db011bf7fb526342f1763999abd62e6b6dd48db5bbbed27c076bf20d3c1b2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

