### PR TITLE
Fix brew completion script for new brew versions

### DIFF
--- a/completions/brew.completion.sh
+++ b/completions/brew.completion.sh
@@ -1,14 +1,14 @@
 #! bash oh-my-bash.module
-if _omb_util_command_exists brew; then
-  _omb_completion_brew_prefix=$(brew --prefix)
-  if [[ $_omb_completion_brew_prefix ]]; then
-    if [[ -f $_omb_completion_brew_prefix/etc/bash_completion ]]; then
-      source "$_omb_completion_brew_prefix"/etc/bash_completion
-    fi
-
-    if [[ -f $_omb_completion_brew_prefix/Library/Contributions/brew_bash_completion.sh ]]; then
-      source "$_omb_completion_brew_prefix"/Library/Contributions/brew_bash_completion.sh
-    fi
+if type brew &>/dev/null
+then
+  HOMEBREW_PREFIX="$(brew --prefix)"
+  if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]
+  then
+    source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
+  else
+    for COMPLETION in "${HOMEBREW_PREFIX}/etc/bash_completion.d/"*
+    do
+      [[ -r "${COMPLETION}" ]] && source "${COMPLETION}"
+    done
   fi
-  unset -v _omb_completion_brew_prefix
 fi


### PR DESCRIPTION
### **User description**
This will fix brew completions. Brew doesn't offer completions on $PREFIX/etc/bash_completion anymore.
According to official brew documentation https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash brew now offers a directory of completions to iterate through.


___

### **PR Type**
Bug fix


___

### **Description**
- Update brew completion script for compatibility with newer brew versions

- Replace deprecated `$PREFIX/etc/bash_completion` with new completion paths

- Add fallback logic to iterate through `bash_completion.d/` directory

- Modernize command existence check and variable naming conventions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old completion paths"] -->|deprecated| B["Single file location"]
  C["New brew structure"] -->|primary| D["etc/profile.d/bash_completion.sh"]
  C -->|fallback| E["etc/bash_completion.d/ directory"]
  D --> F["Sourced completions"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>brew.completion.sh</strong><dd><code>Modernize brew completion sourcing for new versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

completions/brew.completion.sh

<ul><li>Replace <code>_omb_util_command_exists</code> check with <code>type brew</code> command<br> <li> Update completion source paths from deprecated locations to new brew <br>structure<br> <li> Add primary source path <br><code>${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh</code><br> <li> Implement fallback loop to source all completion files from <br><code>bash_completion.d/</code> directory<br> <li> Rename variable from <code>_omb_completion_brew_prefix</code> to <code>HOMEBREW_PREFIX</code> <br>for clarity<br> <li> Remove deprecated completion file paths that no longer exist in newer <br>brew versions</ul>


</details>


  </td>
  <td><a href="https://github.com/ohmybash/oh-my-bash/pull/725/files#diff-82710f5c08a1ead9645ad623313db369e68f9cf83adf96c87311564e5f6f194d">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

