### PR TITLE
fix lucky theme bug

### DIFF
--- a/themes/lucky/lucky.theme.sh
+++ b/themes/lucky/lucky.theme.sh
@@ -14,7 +14,7 @@ SCM_THEME_PROMPT_SUFFIX=$_omb_prompt_normal
 function _omb_theme_PROMPT_COMMAND() {
   local python_venv
   _omb_prompt_get_python_venv
-  PS1=$python_venv
+  PS1='\n'$python_venv
   PS1+=$_omb_prompt_teal'\u '$_omb_prompt_white'@ '$_omb_prompt_green'\h '
   PS1+=$_omb_prompt_white'in '$_omb_prompt_bold_olive'\w'
   PS1+=$(scm_prompt_info)


### PR DESCRIPTION
### **User description**
**Title**: fix(theme): add missing newline in lucky theme

**Description**: This PR fixes a visual bug in themes/lucky/lucky.theme.sh.

**The Issue**: Currently, the prompt does not start on a new line if the preceding command output lacks a trailing newline (e.g., calling a REST API via curl). This results in the prompt being appended directly to the output, making it difficult to read.

**Example of the bug**:
```sh
# curl --location 'http://127.0.0.1:9997/'
{"code":200,"message":"OK"}root @ f10dd4ccacc0 in ~ [15:22:00]
```

Changes:

- Adjusted the prompt configuration in lucky.theme.sh to ensure it renders correctly regardless of previous command output.

I would appreciate it if this could be merged into the master branch.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing newline to lucky theme prompt

- Ensures prompt starts on new line after commands

- Fixes visual bug when output lacks trailing newline


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command Output<br/>without newline"] -- "prompt appended<br/>directly" --> B["Bug: unreadable"]
  C["Command Output<br/>without newline"] -- "newline prefix<br/>added" --> D["Fixed: readable prompt"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lucky.theme.sh</strong><dd><code>Prepend newline to prompt initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

themes/lucky/lucky.theme.sh

<ul><li>Prepend newline character to <code>PS1</code> variable initialization<br> <li> Ensures prompt renders on new line regardless of previous command <br>output<br> <li> Fixes issue where prompt was appended directly to output lacking <br>trailing newline</ul>


</details>


  </td>
  <td><a href="https://github.com/ohmybash/oh-my-bash/pull/728/files#diff-fedabf43ced12f62b6cb6559909d678eaa23f165fbb01b329b497e3d2e08e23f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

