### PR TITLE
fix(lib/base): Change hyphen to underscore in banish_cookies function

### DIFF
--- a/lib/base.sh
+++ b/lib/base.sh
@@ -57,9 +57,9 @@ function quiet {
 # shellcheck disable=SC2010
 function lsgrep { ls | grep "$*" ; }
 
-#   banish-cookies: redirect .adobe and .macromedia files to /dev/null
+#   banish_cookies: redirect .adobe and .macromedia files to /dev/null
 #   ------------------------------------------------------------
-function banish-cookies {
+function banish_cookies {
   rm -r ~/.macromedia ~/.adobe
   ln -s /dev/null ~/.adobe
   ln -s /dev/null ~/.macromedia


### PR DESCRIPTION
### **User description**
Renamed `banish-cookies` function to `banish_cookies` to fix invalid identifier

https://www.gnu.org/software/bash/manual/bash.html#index-identifier
> A word consisting solely of letters, numbers, and underscores, and beginning with a letter or underscore. Names are used as shell variable and function names. Also referred to as an identifier.

Currently, this warning is given when `lib/bash.sh` is sourced (i.e. when invoking an interactive shell)
```
~/git/oh-my-bash (master) $ source lib/base.sh
bash: `banish-cookies': not a valid identifier`
```


___

### **PR Type**
Bug fix


___

### **Description**
- Renamed `banish-cookies` function to `banish_cookies`

- Fixed invalid bash identifier with hyphen character

- Resolves bash warning when sourcing `lib/base.sh`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["banish-cookies<br/>invalid identifier"] -- "rename to valid identifier" --> B["banish_cookies<br/>valid identifier"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.sh</strong><dd><code>Rename function with hyphen to underscore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/base.sh

<ul><li>Renamed function from <code>banish-cookies</code> to <code>banish_cookies</code><br> <li> Updated function comment to reflect new name<br> <li> Fixes bash identifier validation error</ul>


</details>


  </td>
  <td><a href="https://github.com/ohmybash/oh-my-bash/pull/729/files#diff-fd079fed9e4b4ea98624a4c9e954e5f42de782fc5d0395e60e53a24bca696e39">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

