### PR TITLE
fix(lib/shopt): Only enable noclobber in interactive shells

### DIFF
--- a/lib/shopt.sh
+++ b/lib/shopt.sh
@@ -13,7 +13,18 @@
 
 # Prevent file overwrite on stdout redirection
 # Use `>|` to force redirection to an existing file
-set -o noclobber
+#
+# Note: The noclobber option is designed for interactive use to prevent
+# accidental file overwrites by the user.  Scripts and non-interactive
+# environments (e.g., IDE environment readers) do not need this protection
+# and may actually break when noclobber is enabled.  For example, JetBrains
+# IDEs fail to load shell environment variables because their environment
+# reader uses `>` redirection to a temp file.  See Ref. [1] for details.
+#
+# [1] https://github.com/ohmybash/oh-my-bash/issues/453
+case $- in
+  *i*) set -o noclobber ;;
+esac
 
 # Update window size after every command
 shopt -s checkwinsize


### PR DESCRIPTION
### **User description**
## Summary

The `noclobber` option is designed for interactive use to prevent accidental file overwrites by the user. Scripts and non-interactive environments do not need this protection and may actually break when `noclobber` is enabled.

For example, JetBrains IDEs fail to load shell environment variables because their environment reader uses `>` redirection to a temp file, which fails when `noclobber` is set.

## Changes

- Wrap `set -o noclobber` in a `case $-` check to only enable it in interactive shells (`*i*`)

## Test Plan

- [x] Verified that `noclobber` is still enabled in interactive bash sessions
- [x] Verified that JetBrains GoLand 2025.3 can now successfully load shell environment variables (52 vars loaded vs 16 vars before the fix)

Fixes #453


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap `noclobber` option in interactive shell check

- Prevents script failures in non-interactive environments

- Fixes JetBrains IDE environment variable loading issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["noclobber setting"] --> B{"Interactive shell?"}
  B -->|Yes| C["Enable noclobber"]
  B -->|No| D["Skip noclobber"]
  C --> E["Protect from accidental overwrites"]
  D --> F["Allow scripts to run normally"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shopt.sh</strong><dd><code>Conditionally enable noclobber for interactive shells</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/shopt.sh

<ul><li>Wrapped <code>set -o noclobber</code> in a <code>case $-</code> conditional check<br> <li> Added comprehensive comments explaining why noclobber is <br>interactive-only<br> <li> Only enables noclobber when shell flag contains <code>i</code> (interactive mode)<br> <li> Prevents breaking non-interactive environments like IDE environment <br>readers</ul>


</details>


  </td>
  <td><a href="https://github.com/ohmybash/oh-my-bash/pull/732/files#diff-2ae4679d7f94c33fe29ef6bbc3a3934a09961a31c8ec7f86c0e06fd96583c6ec">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

