### PR TITLE
feat(kube-ps1): add kube-ps1 plugin

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -347,8 +347,11 @@ _omb_util_unload_hook+=('PS1=$_omb_util_original_PS1')
 
 _omb_util_prompt_command=()
 function _omb_util_prompt_command_hook {
-  local status=$? lastarg=$_ hook
-  for hook in "${_omb_util_prompt_command[@]}"; do
+  local status=$? lastarg=$_ hook i
+  # Use an index loop so hooks registered mid-cycle (e.g. by earlier hooks) are
+  # picked up in the same prompt-render cycle rather than deferred to the next.
+  for ((i = 0; i < ${#_omb_util_prompt_command[@]}; i++)); do
+    hook=${_omb_util_prompt_command[i]}
     _omb_util_setexit "$status" "$lastarg"
     eval -- "$hook"
   done

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -45,6 +45,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | golang            | The Go programming language, along with its tools and standard libraries.                                                   |
 | jump              | Jump helps you navigate faster by learning your habits.                                                                     |
 | kubectl           | Command-line tool for interacting with Kubernetes clusters.                                                                 |
+| [kube-ps1](kube-ps1) | Displays the current Kubernetes context and namespace in the shell prompt.                                               |
 | npm               | Package manager for Node.js facilitating installation and management of project dependencies.                               |
 | nvm               | Node.js version manager allowing easy switching between different Node.js versions.                                         |
 | progress          | Insufficient information provided to give a precise description.                                                            |

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -45,7 +45,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | golang            | The Go programming language, along with its tools and standard libraries.                                                   |
 | jump              | Jump helps you navigate faster by learning your habits.                                                                     |
 | kubectl           | Command-line tool for interacting with Kubernetes clusters.                                                                 |
-| [kube-ps1](kube-ps1) | Displays the current Kubernetes context and namespace in the shell prompt.                                               |
+| kube-ps1          | Displays the current Kubernetes context and namespace in the shell prompt.                                                  |
 | npm               | Package manager for Node.js facilitating installation and management of project dependencies.                               |
 | nvm               | Node.js version manager allowing easy switching between different Node.js versions.                                         |
 | progress          | Insufficient information provided to give a precise description.                                                            |

--- a/plugins/kube-ps1/LICENSE
+++ b/plugins/kube-ps1/LICENSE
@@ -1,0 +1,179 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and the Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any Work
+      incorporated within the Work constitutes direct or contributory patent
+      infringement, then any patent licenses granted to You under this License
+      for that Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the Work
+      or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You meet
+      the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative Works
+          a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works that
+          You distribute, all copyright, patent, trademark, and attribution
+          notices from the Source form of the Work, excluding those notices
+          that do not pertain to any part of the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file, You must include a
+          readable copy of the attribution notices contained in such NOTICE
+          file, in at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within the Source
+          form or documentation, if provided along with the Derivative Works;
+          or, within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents of
+          the NOTICE file are for informational purposes only and do not
+          modify the License. You may add Your own attribution notices within
+          Derivative Works that You distribute, alongside or as an addendum
+          to the NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and may
+      provide additional grant of rights to use, copy, modify, merge, publish,
+      distribute, sublicense, and/or sell copies of Your modifications, and
+      to permit persons to whom the Software is furnished to do so, subject to
+      the conditions in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work by
+      You to the Licensor shall be under the terms and conditions of this
+      License, without any additional terms or conditions. Notwithstanding
+      the above, nothing herein shall supersede or modify the terms of any
+      separate license agreement you may have executed with Licensor regarding
+      such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or agreed
+      to in writing, Licensor provides the Work (and each Contributor provides
+      its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+      CONDITIONS OF ANY KIND, either express or implied, including, without
+      limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+      MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely
+      responsible for determining the appropriateness of using or reproducing
+      the Work and assume any risks associated with Your exercise of
+      permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise, unless
+      required by applicable law (such as deliberate and grossly negligent
+      acts) or agreed to in writing, shall any Contributor be liable to You
+      for damages, including any direct, indirect, special, incidental, or
+      consequential damages of any character arising as a result of this
+      License or out of the use or inability to use the Work (including but
+      not limited to damages for loss of goodwill, work stoppage, computer
+      failure or malfunction, or all other commercial damages or losses), even
+      if such Contributor has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing the
+      Work or Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such obligations only on Your
+      own behalf and on Your sole responsibility, not on behalf of any other
+      Contributor, and only if You agree to indemnify, defend, and hold each
+      Contributor harmless for any liability incurred by, or claims asserted
+      against, such Contributor by reason of your accepting any warranty or
+      additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2020 Jon Mosco
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/kube-ps1/README.md
+++ b/plugins/kube-ps1/README.md
@@ -1,0 +1,114 @@
+# kube-ps1 plugin
+
+Displays the current [Kubernetes](https://kubernetes.io) context and namespace
+in the shell prompt.
+
+This plugin is a derivative work of
+[kube-ps1](https://github.com/jonmosco/kube-ps1) by Jon Mosco, adapted for
+Oh My Bash.
+
+## License & notices
+
+The original `kube-ps1` is Copyright 2020 Jon Mosco and is distributed under
+the [Apache License, Version 2.0](LICENSE).  A copy of that license is
+included in this directory (`plugins/kube-ps1/LICENSE`).
+
+This adapted version is also provided under the Apache License 2.0 alongside
+the MIT license that covers Oh My Bash as a whole.
+
+The original script can be found at
+<https://github.com/jonmosco/kube-ps1/blob/master/kube-ps1.sh>.
+
+---
+
+## Requirements
+
+* `kubectl` (or the binary set in `KUBE_PS1_BINARY`) must be installed and
+  reachable in `$PATH`.
+
+## Enable the plugin
+
+Add `kube-ps1` to the `plugins` array in your `~/.bashrc`:
+
+```bash
+plugins=(... kube-ps1)
+```
+
+## Add to your prompt
+
+The plugin exposes a `kube_ps1` function that outputs the formatted context
+string.  Add it to your `PS1` (or to your theme's
+`_omb_theme_PROMPT_COMMAND`):
+
+```bash
+PS1='[\u@\h \W $(kube_ps1)]\$ '
+```
+
+## Commands
+
+| Command         | Description                                          |
+|:----------------|:-----------------------------------------------------|
+| `kubeon`        | Enable the kube-ps1 prompt for this shell session    |
+| `kubeon -g`     | Enable the kube-ps1 prompt globally (persistent)     |
+| `kubeoff`       | Disable the kube-ps1 prompt for this shell session   |
+| `kubeoff -g`    | Disable the kube-ps1 prompt globally (persistent)    |
+
+## Configuration
+
+All variables can be set in `~/.bashrc` **before** oh-my-bash is sourced.
+
+### Display
+
+| Variable                    | Default   | Description                                           |
+|:----------------------------|:----------|:------------------------------------------------------|
+| `KUBE_PS1_BINARY`           | `kubectl` | Binary used to read context/namespace                 |
+| `KUBE_PS1_SYMBOL_ENABLE`    | `true`    | Show/hide the Kubernetes symbol (⎈)                   |
+| `KUBE_PS1_SYMBOL_PADDING`   | `false`   | Add a trailing space after the symbol                 |
+| `KUBE_PS1_SYMBOL_CUSTOM`    | _(empty)_ | Use a custom symbol: `img`, `k8s`, `oc`, or any char  |
+| `KUBE_PS1_CONTEXT_ENABLE`   | `true`    | Show/hide the context name                            |
+| `KUBE_PS1_NS_ENABLE`        | `true`    | Show/hide the namespace name                          |
+| `KUBE_PS1_PREFIX`           | `(`       | String prepended to the prompt segment                |
+| `KUBE_PS1_SUFFIX`           | `)`       | String appended to the prompt segment                 |
+| `KUBE_PS1_SEPARATOR`        | `\|`      | Separator between symbol and context                  |
+| `KUBE_PS1_DIVIDER`          | `:`       | Separator between context and namespace               |
+| `KUBE_PS1_HIDE_IF_NOCONTEXT`| `false`   | Hide the segment entirely when no context is active   |
+
+### Colours
+
+| Variable                | Default   | Description                                              |
+|:------------------------|:----------|:---------------------------------------------------------|
+| `KUBE_PS1_CTX_COLOR`    | `red`     | Context name colour                                      |
+| `KUBE_PS1_NS_COLOR`     | `cyan`    | Namespace colour                                         |
+| `KUBE_PS1_SYMBOL_COLOR` | `blue`    | Symbol colour                                            |
+| `KUBE_PS1_PREFIX_COLOR` | _(empty)_ | Prefix colour (empty = no colour code)                   |
+| `KUBE_PS1_SUFFIX_COLOR` | _(empty)_ | Suffix colour (empty = no colour code)                   |
+| `KUBE_PS1_BG_COLOR`     | _(empty)_ | Background colour for the whole segment                  |
+
+Accepted colour values: `black`, `red`, `green`, `yellow`, `blue`,
+`magenta`, `cyan`, `white`, or an integer `0`–`255` for 256-colour
+terminals.
+
+### Custom functions
+
+You can provide shell functions to dynamically transform or colour values:
+
+| Variable                      | Signature                              | Description                                       |
+|:------------------------------|:---------------------------------------|:--------------------------------------------------|
+| `KUBE_PS1_CLUSTER_FUNCTION`   | `my_fn <context>  → string`            | Transform the context name before display         |
+| `KUBE_PS1_NAMESPACE_FUNCTION` | `my_fn <namespace> → string`           | Transform the namespace before display            |
+| `KUBE_PS1_CTX_COLOR_FUNCTION` | `my_fn <context>  → colour`            | Return a colour name/number for the context       |
+
+## Example
+
+```bash
+# ~/.bashrc
+
+# Show only the last segment of the context name
+kube_short_ctx() { printf '%s' "${1##*/}"; }
+export KUBE_PS1_CLUSTER_FUNCTION=kube_short_ctx
+
+plugins=(... kube-ps1)
+source "$OSH"/oh-my-bash.sh
+
+PS1='[\u@\h \W $(kube_ps1)]\$ '
+```

--- a/plugins/kube-ps1/README.md
+++ b/plugins/kube-ps1/README.md
@@ -34,15 +34,21 @@ Add `kube-ps1` to the `plugins` array in your `~/.bashrc`:
 plugins=(... kube-ps1)
 ```
 
-## Add to your prompt
+## How the segment appears in your prompt
 
-The plugin exposes a `kube_ps1` function that outputs the formatted context
-string.  Add it to your `PS1` (or to your theme's
-`_omb_theme_PROMPT_COMMAND`):
+Enabling the plugin is all that is required — no changes to `PS1` are needed.
+The plugin automatically prepends the kube segment to whatever `PS1` your
+active theme sets, on every command.
+
+If you prefer to control the exact position of the segment yourself (e.g.
+from a custom theme or a hand-crafted `PS1`), embed `$(kube_ps1)` literally:
 
 ```bash
 PS1='[\u@\h \W $(kube_ps1)]\$ '
 ```
+
+> **Note:** do not do both. When `$(kube_ps1)` is already present in `PS1`
+> literally, the automatic injection is skipped to prevent duplication.
 
 ## Commands
 

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -168,8 +168,14 @@ _omb_plugin_kube_ps1_symbol() {
 # ---------------------------------------------------------------------------
 _omb_plugin_kube_ps1_split_config() {
   local IFS="$1"
-  # word-split on IFS
+  # Disable globbing so unquoted $2 only word-splits on IFS and does not
+  # expand wildcards that may appear in KUBECONFIG paths.
+  local _glob_state=$-
+  set -f
+  # shellcheck disable=SC2086  # intentional word-splitting on IFS
   printf '%s\n' $2
+  # Restore globbing only if it was enabled before this call.
+  [[ $_glob_state == *f* ]] || set +f
 }
 
 _omb_plugin_kube_ps1_file_newer_than() {
@@ -229,9 +235,13 @@ _omb_plugin_kube_ps1_get_context_ns() {
 # ---------------------------------------------------------------------------
 # PS1 appender – injects the kube segment into PS1 after the theme sets it.
 # Registered lazily on first PROMPT_COMMAND run so it is always last.
+# Skips injection when PS1 already contains $(kube_ps1) literally, meaning
+# the user has chosen to embed it manually in their PS1 or theme.
 # ---------------------------------------------------------------------------
 _omb_plugin_kube_ps1_ps1_append() {
   [[ "${KUBE_PS1_ENABLED:-on}" == "off" ]] && return
+  # If the user already has $(kube_ps1) in their PS1, do not inject again.
+  [[ "${PS1}" == *'$(kube_ps1)'* ]] && return
   local seg
   seg="$(kube_ps1)" || return
   [[ -z "$seg" ]] && return

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -141,7 +141,7 @@ _omb_plugin_kube_ps1_symbol() {
       symbol=$'\xE2\x98\xB8'  # ☸ (UTF-8 bytes for bash < 4)
       ;;
     k8s)
-      symbol="$(_omb_plugin_kube_ps1_color_fg "${KUBE_PS1_SYMBOL_COLOR}")$'\Uf10fe'${reset_color}"
+      symbol="$(_omb_plugin_kube_ps1_color_fg "${KUBE_PS1_SYMBOL_COLOR}")$'\U000f10fe'${reset_color}"
       ;;
     oc)
       symbol="$(_omb_plugin_kube_ps1_color_fg red)$'\ue7b7'${reset_color}"

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -262,6 +262,8 @@ _omb_plugin_kube_ps1_prompt_update() {
 
   # Lazy first-run: register ps1_append AFTER the theme has been added to
   # _omb_util_prompt_command, so it always executes last.
+  # _omb_util_prompt_command_hook uses an index loop, so the newly registered
+  # function is invoked in the same prompt-render cycle it is added.
   if [[ "${_omb_plugin_kube_ps1_initialized}" == false ]]; then
     _omb_plugin_kube_ps1_initialized=true
     _omb_util_add_prompt_command _omb_plugin_kube_ps1_ps1_append

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -245,8 +245,13 @@ _omb_plugin_kube_ps1_ps1_append() {
   local seg
   seg="$(kube_ps1)" || return
   [[ -z "$seg" ]] && return
-  # Prepend the segment so it appears before the theme's own prompt text
-  PS1="${seg} ${PS1}"
+  # Prepend the segment so it appears before the theme's own prompt text.
+  # Skip the separator space if the segment already ends with a newline.
+  if [[ "${seg}" == *$'\n' ]]; then
+    PS1="${seg}${PS1}"
+  else
+    PS1="${seg} ${PS1}"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -1,0 +1,422 @@
+#! bash oh-my-bash.module
+#
+# Kubernetes prompt helper for bash/zsh
+# Displays current context and namespace
+#
+# Copyright 2020 Jon Mosco
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ---------------------------------------------------------------------------
+#
+# This file is a derivative work based on kube-ps1
+# <https://github.com/jonmosco/kube-ps1>.
+#
+# ---------------------------------------------------------------------------
+#
+# Usage: add $(kube_ps1) to your PS1 or theme, and use
+#   kubeon  / kubeoff  to toggle the prompt info.
+#
+# ---------------------------------------------------------------------------
+
+# Debug
+[[ -n ${DEBUG:-} ]] && set -x
+
+# ---------------------------------------------------------------------------
+# Public configuration variables (override in ~/.bashrc before loading OMB)
+# ---------------------------------------------------------------------------
+KUBE_PS1_BINARY="${KUBE_PS1_BINARY:-kubectl}"
+KUBE_PS1_SYMBOL_ENABLE="${KUBE_PS1_SYMBOL_ENABLE:-true}"
+KUBE_PS1_SYMBOL_PADDING="${KUBE_PS1_SYMBOL_PADDING:-false}"
+KUBE_PS1_SYMBOL_COLOR="${KUBE_PS1_SYMBOL_COLOR:-blue}"
+KUBE_PS1_SYMBOL_CUSTOM="${KUBE_PS1_SYMBOL_CUSTOM:-}"
+
+KUBE_PS1_CTX_COLOR="${KUBE_PS1_CTX_COLOR:-red}"
+KUBE_PS1_NS_COLOR="${KUBE_PS1_NS_COLOR:-cyan}"
+KUBE_PS1_PREFIX_COLOR="${KUBE_PS1_PREFIX_COLOR:-}"
+KUBE_PS1_SUFFIX_COLOR="${KUBE_PS1_SUFFIX_COLOR:-}"
+KUBE_PS1_BG_COLOR="${KUBE_PS1_BG_COLOR:-}"
+
+KUBE_PS1_NS_ENABLE="${KUBE_PS1_NS_ENABLE:-true}"
+KUBE_PS1_CONTEXT_ENABLE="${KUBE_PS1_CONTEXT_ENABLE:-true}"
+KUBE_PS1_PREFIX="${KUBE_PS1_PREFIX-(}"
+KUBE_PS1_SEPARATOR="${KUBE_PS1_SEPARATOR-|}"
+KUBE_PS1_DIVIDER="${KUBE_PS1_DIVIDER-:}"
+KUBE_PS1_SUFFIX="${KUBE_PS1_SUFFIX-)}"
+
+KUBE_PS1_HIDE_IF_NOCONTEXT="${KUBE_PS1_HIDE_IF_NOCONTEXT:-false}"
+
+# Optional user-supplied functions to transform or color context/namespace
+# KUBE_PS1_CLUSTER_FUNCTION=""
+# KUBE_PS1_NAMESPACE_FUNCTION=""
+# KUBE_PS1_CTX_COLOR_FUNCTION=""
+
+# ---------------------------------------------------------------------------
+# Internal state variables
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_kubeconfig_cache="${KUBECONFIG}"
+_omb_plugin_kube_ps1_disable_path="${HOME}/.kube/kube-ps1/disabled"
+_omb_plugin_kube_ps1_last_time=0
+_omb_plugin_kube_ps1_cfgfiles_read_cache=
+_omb_plugin_kube_ps1_initialized=false
+
+# Escape sequences for bash prompt
+_KUBE_PS1_OPEN_ESC=$'\001'
+_KUBE_PS1_CLOSE_ESC=$'\002'
+_KUBE_PS1_DEFAULT_BG=$'\033[49m'
+_KUBE_PS1_DEFAULT_FG=$'\033[39m'
+
+# ---------------------------------------------------------------------------
+# Colour helpers
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_color_fg() {
+  local code
+  case "${1}" in
+    black)   code=0 ;;
+    red)     code=1 ;;
+    green)   code=2 ;;
+    yellow)  code=3 ;;
+    blue)    code=4 ;;
+    magenta) code=5 ;;
+    cyan)    code=6 ;;
+    white)   code=7 ;;
+    [0-9]|[1-9][0-9]|[1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]) code="${1}" ;;
+    *) printf '%s' "${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_CLOSE_ESC}"; return ;;
+  esac
+
+  local seq
+  if tput setaf 1 &>/dev/null; then
+    seq="$(tput setaf "${code}")"
+  else
+    seq="\033[38;5;${code}m"
+  fi
+  printf '%s' "${_KUBE_PS1_OPEN_ESC}${seq}${_KUBE_PS1_CLOSE_ESC}"
+}
+
+_omb_plugin_kube_ps1_color_bg() {
+  local code
+  case "${1}" in
+    black)   code=0 ;;
+    red)     code=1 ;;
+    green)   code=2 ;;
+    yellow)  code=3 ;;
+    blue)    code=4 ;;
+    magenta) code=5 ;;
+    cyan)    code=6 ;;
+    white)   code=7 ;;
+    [0-9]|[1-9][0-9]|[1][0-9][0-9]|[2][0-4][0-9]|[2][5][0-5]) code="${1}" ;;
+    *) printf '%s' "${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_BG}${_KUBE_PS1_CLOSE_ESC}"; return ;;
+  esac
+
+  local seq
+  if tput setab 1 &>/dev/null; then
+    seq="$(tput setab "${code}")"
+  else
+    seq="\033[48;5;${code}m"
+  fi
+  printf '%s' "${_KUBE_PS1_OPEN_ESC}${seq}${_KUBE_PS1_CLOSE_ESC}"
+}
+
+# ---------------------------------------------------------------------------
+# Symbol
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_symbol() {
+  [[ "${KUBE_PS1_SYMBOL_ENABLE}" == false ]] && return
+
+  local reset_color="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_CLOSE_ESC}"
+  local symbol
+
+  case "${KUBE_PS1_SYMBOL_CUSTOM:-}" in
+    img)
+      symbol=$'\xE2\x98\xB8'  # ☸ (UTF-8 bytes for bash < 4)
+      ;;
+    k8s)
+      symbol="$(_omb_plugin_kube_ps1_color_fg "${KUBE_PS1_SYMBOL_COLOR}")$'\Uf10fe'${reset_color}"
+      ;;
+    oc)
+      symbol="$(_omb_plugin_kube_ps1_color_fg red)$'\ue7b7'${reset_color}"
+      ;;
+    *)
+      # Use unicode helm symbol; fall back to UTF-8 bytes for old bash
+      if ((BASH_VERSINFO[0] >= 4)) && [[ $'\u2388' != "\\u2388" ]]; then
+        symbol="$(_omb_plugin_kube_ps1_color_fg "${KUBE_PS1_SYMBOL_COLOR}")"$'\u2388'"${reset_color}"
+      else
+        symbol=$'\xE2\x8E\x88'
+      fi
+      ;;
+  esac
+
+  if [[ "${KUBE_PS1_SYMBOL_PADDING}" == true ]]; then
+    printf '%s ' "${symbol}"
+  else
+    printf '%s' "${symbol}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Config-file helpers
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_split_config() {
+  local IFS="$1"
+  # word-split on IFS
+  printf '%s\n' $2
+}
+
+_omb_plugin_kube_ps1_file_newer_than() {
+  local file="$1" check_time="$2" mtime
+  if stat -c "%s" /dev/null &>/dev/null; then
+    # GNU stat
+    mtime=$(stat -L -c %Y "${file}")
+  else
+    # BSD stat (macOS)
+    mtime=$(stat -L -f %m "${file}")
+  fi
+  (( mtime > check_time ))
+}
+
+# ---------------------------------------------------------------------------
+# Context / namespace fetching
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_get_context() {
+  [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]] || return
+  KUBE_PS1_CONTEXT="$(${KUBE_PS1_BINARY} config current-context 2>/dev/null)"
+  KUBE_PS1_CONTEXT="${KUBE_PS1_CONTEXT:-N/A}"
+  if [[ -n "${KUBE_PS1_CLUSTER_FUNCTION:-}" ]]; then
+    KUBE_PS1_CONTEXT="$("${KUBE_PS1_CLUSTER_FUNCTION}" "${KUBE_PS1_CONTEXT}")"
+  fi
+}
+
+_omb_plugin_kube_ps1_get_ns() {
+  [[ "${KUBE_PS1_NS_ENABLE}" == true ]] || return
+  KUBE_PS1_NAMESPACE="$(${KUBE_PS1_BINARY} config view --minify --output 'jsonpath={..namespace}' 2>/dev/null)"
+  KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
+  if [[ -n "${KUBE_PS1_NAMESPACE_FUNCTION:-}" ]]; then
+    KUBE_PS1_NAMESPACE="$("${KUBE_PS1_NAMESPACE_FUNCTION}" "${KUBE_PS1_NAMESPACE}")"
+  fi
+}
+
+_omb_plugin_kube_ps1_get_context_ns() {
+  if ((BASH_VERSINFO[0] >= 4 && BASH_VERSINFO[1] >= 2)); then
+    _omb_plugin_kube_ps1_last_time=$(printf '%(%s)T')
+  else
+    _omb_plugin_kube_ps1_last_time=$(date +%s)
+  fi
+
+  KUBE_PS1_CONTEXT="${KUBE_PS1_CONTEXT:-N/A}"
+  KUBE_PS1_NAMESPACE="${KUBE_PS1_NAMESPACE:-default}"
+
+  # Build cache of readable config files
+  local conf
+  _omb_plugin_kube_ps1_cfgfiles_read_cache=
+  while IFS= read -r conf; do
+    [[ -r "${conf}" ]] && _omb_plugin_kube_ps1_cfgfiles_read_cache+=":${conf}"
+  done < <(_omb_plugin_kube_ps1_split_config : "${KUBECONFIG:-${HOME}/.kube/config}")
+
+  _omb_plugin_kube_ps1_get_context
+  _omb_plugin_kube_ps1_get_ns
+}
+
+# ---------------------------------------------------------------------------
+# PS1 appender – injects the kube segment into PS1 after the theme sets it.
+# Registered lazily on first PROMPT_COMMAND run so it is always last.
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_ps1_append() {
+  [[ "${KUBE_PS1_ENABLED:-on}" == "off" ]] && return
+  local seg
+  seg="$(kube_ps1)" || return
+  [[ -z "$seg" ]] && return
+  # Prepend the segment so it appears before the theme's own prompt text
+  PS1="${seg} ${PS1}"
+}
+
+# ---------------------------------------------------------------------------
+# PROMPT_COMMAND hook – updates KUBE_PS1_CONTEXT / KUBE_PS1_NAMESPACE
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_prompt_update() {
+  local return_code=$?
+
+  # Lazy first-run: register ps1_append AFTER the theme has been added to
+  # _omb_util_prompt_command, so it always executes last.
+  if [[ "${_omb_plugin_kube_ps1_initialized}" == false ]]; then
+    _omb_plugin_kube_ps1_initialized=true
+    _omb_util_add_prompt_command _omb_plugin_kube_ps1_ps1_append
+  fi
+
+  [[ "${KUBE_PS1_ENABLED:-on}" == "off" ]] && return $return_code
+
+  if ! _omb_util_command_exists "${KUBE_PS1_BINARY}"; then
+    KUBE_PS1_CONTEXT="BINARY-N/A"
+    KUBE_PS1_NAMESPACE="N/A"
+    return $return_code
+  fi
+
+  if [[ "${KUBECONFIG}" != "${_omb_plugin_kube_ps1_kubeconfig_cache}" ]]; then
+    _omb_plugin_kube_ps1_kubeconfig_cache="${KUBECONFIG}"
+    _omb_plugin_kube_ps1_get_context_ns
+    return $return_code
+  fi
+
+  local conf config_file_cache=
+  while IFS= read -r conf; do
+    [[ -r "${conf}" ]] || continue
+    config_file_cache+=":${conf}"
+    if _omb_plugin_kube_ps1_file_newer_than "${conf}" \
+        "${_omb_plugin_kube_ps1_last_time}"; then
+      _omb_plugin_kube_ps1_get_context_ns
+      return $return_code
+    fi
+  done < <(_omb_plugin_kube_ps1_split_config : "${KUBECONFIG:-${HOME}/.kube/config}")
+
+  if [[ "${config_file_cache}" != "${_omb_plugin_kube_ps1_cfgfiles_read_cache}" ]]; then
+    _omb_plugin_kube_ps1_get_context_ns
+  fi
+
+  return $return_code
+}
+
+# Register the hook
+_omb_util_add_prompt_command _omb_plugin_kube_ps1_prompt_update
+
+# ---------------------------------------------------------------------------
+# Honour a persistent "disabled" marker on startup
+# ---------------------------------------------------------------------------
+[[ -f "${_omb_plugin_kube_ps1_disable_path}" ]] && KUBE_PS1_ENABLED=off
+
+# ---------------------------------------------------------------------------
+# kubeon / kubeoff
+# ---------------------------------------------------------------------------
+_omb_plugin_kube_ps1_kubeon_usage() {
+  cat <<'EOF'
+Toggle kube-ps1 prompt on
+
+Usage: kubeon [-g | --global] [-h | --help]
+
+With no arguments, turn on kube-ps1 status for this shell instance (default).
+
+  -g --global  turn on kube-ps1 status globally
+  -h --help    print this message
+EOF
+}
+
+_omb_plugin_kube_ps1_kubeoff_usage() {
+  cat <<'EOF'
+Toggle kube-ps1 prompt off
+
+Usage: kubeoff [-g | --global] [-h | --help]
+
+With no arguments, turn off kube-ps1 status for this shell instance (default).
+
+  -g --global  turn off kube-ps1 status globally
+  -h --help    print this message
+EOF
+}
+
+kubeon() {
+  case "${1:-}" in
+    -h|--help)
+      _omb_plugin_kube_ps1_kubeon_usage ;;
+    -g|--global)
+      rm -f -- "${_omb_plugin_kube_ps1_disable_path}"
+      KUBE_PS1_ENABLED=on ;;
+    "")
+      KUBE_PS1_ENABLED=on ;;
+    *)
+      printf 'error: unrecognized flag %s\n\n' "${1}" >&2
+      _omb_plugin_kube_ps1_kubeon_usage
+      return 1 ;;
+  esac
+}
+
+kubeoff() {
+  case "${1:-}" in
+    -h|--help)
+      _omb_plugin_kube_ps1_kubeoff_usage ;;
+    -g|--global)
+      mkdir -p -- "$(dirname "${_omb_plugin_kube_ps1_disable_path}")"
+      touch -- "${_omb_plugin_kube_ps1_disable_path}"
+      KUBE_PS1_ENABLED=off ;;
+    "")
+      KUBE_PS1_ENABLED=off ;;
+    *)
+      printf 'error: unrecognized flag %s\n\n' "${1}" >&2
+      _omb_plugin_kube_ps1_kubeoff_usage
+      return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# kube_ps1 – the function to embed in PS1
+#
+# Usage in a theme or ~/.bashrc:
+#   PS1='... $(kube_ps1) ...'
+# ---------------------------------------------------------------------------
+kube_ps1() {
+  [[ "${KUBE_PS1_ENABLED:-on}" == "off" ]] && return
+  [[ -z "${KUBE_PS1_CONTEXT:-}" ]] && [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]] && return
+  [[ "${KUBE_PS1_CONTEXT:-}" == "N/A" ]] && [[ "${KUBE_PS1_HIDE_IF_NOCONTEXT}" == true ]] && return
+
+  local reset_color="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_CLOSE_ESC}"
+  if [[ -n "${KUBE_PS1_BG_COLOR:-}" ]]; then
+    reset_color="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_DEFAULT_BG}${_KUBE_PS1_CLOSE_ESC}"
+  fi
+
+  local kube_ps1=
+
+  # Background colour
+  [[ -n "${KUBE_PS1_BG_COLOR:-}" ]] && \
+    kube_ps1+="$(_omb_plugin_kube_ps1_color_bg "${KUBE_PS1_BG_COLOR}")"
+
+  # Prefix
+  if [[ -z "${KUBE_PS1_PREFIX_COLOR:-}" ]]; then
+    kube_ps1+="${KUBE_PS1_PREFIX}"
+  else
+    kube_ps1+="$(_omb_plugin_kube_ps1_color_fg "${KUBE_PS1_PREFIX_COLOR}")${KUBE_PS1_PREFIX}${reset_color}"
+  fi
+
+  # Symbol
+  kube_ps1+="$(_omb_plugin_kube_ps1_symbol)"
+
+  if [[ -n "${KUBE_PS1_SEPARATOR}" ]] && [[ "${KUBE_PS1_SYMBOL_ENABLE}" == true ]]; then
+    kube_ps1+="${KUBE_PS1_SEPARATOR}"
+  fi
+
+  # Context
+  if [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]]; then
+    local ctx_color="${KUBE_PS1_CTX_COLOR:-red}"
+    if [[ -n "${KUBE_PS1_CTX_COLOR_FUNCTION:-}" ]]; then
+      ctx_color="$("${KUBE_PS1_CTX_COLOR_FUNCTION}" "${KUBE_PS1_CONTEXT}")"
+    fi
+    kube_ps1+="$(_omb_plugin_kube_ps1_color_fg "${ctx_color}")${KUBE_PS1_CONTEXT}${reset_color}"
+  fi
+
+  # Namespace
+  if [[ "${KUBE_PS1_NS_ENABLE}" == true ]]; then
+    if [[ -n "${KUBE_PS1_DIVIDER}" ]] && [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]]; then
+      kube_ps1+="${KUBE_PS1_DIVIDER}"
+    fi
+    kube_ps1+="$(_omb_plugin_kube_ps1_color_fg "${KUBE_PS1_NS_COLOR:-cyan}")${KUBE_PS1_NAMESPACE}${reset_color}"
+  fi
+
+  # Suffix
+  if [[ -z "${KUBE_PS1_SUFFIX_COLOR:-}" ]]; then
+    kube_ps1+="${KUBE_PS1_SUFFIX}"
+  else
+    kube_ps1+="$(_omb_plugin_kube_ps1_color_fg "${KUBE_PS1_SUFFIX_COLOR}")${KUBE_PS1_SUFFIX}${reset_color}"
+  fi
+
+  # Close background colour
+  [[ -n "${KUBE_PS1_BG_COLOR:-}" ]] && \
+    kube_ps1+="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_BG}${_KUBE_PS1_CLOSE_ESC}"
+
+  printf '%s' "${kube_ps1}"
+}

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -343,7 +343,10 @@ kubeon() {
     -h|--help)
       _omb_plugin_kube_ps1_kubeon_usage ;;
     -g|--global)
-      rm -f -- "${_omb_plugin_kube_ps1_disable_path}"
+      if ! rm -f -- "${_omb_plugin_kube_ps1_disable_path}"; then
+        printf 'error: kubeon: failed to remove disable file: %s\n' "${_omb_plugin_kube_ps1_disable_path}" >&2
+        return 1
+      fi
       KUBE_PS1_ENABLED=on ;;
     "")
       KUBE_PS1_ENABLED=on ;;
@@ -359,8 +362,14 @@ kubeoff() {
     -h|--help)
       _omb_plugin_kube_ps1_kubeoff_usage ;;
     -g|--global)
-      mkdir -p -- "$(dirname "${_omb_plugin_kube_ps1_disable_path}")"
-      touch -- "${_omb_plugin_kube_ps1_disable_path}"
+      if ! mkdir -p -- "$(dirname "${_omb_plugin_kube_ps1_disable_path}")"; then
+        printf 'error: kubeoff: failed to create directory for disable file: %s\n' "$(dirname "${_omb_plugin_kube_ps1_disable_path}")" >&2
+        return 1
+      fi
+      if ! touch -- "${_omb_plugin_kube_ps1_disable_path}"; then
+        printf 'error: kubeoff: failed to create disable file: %s\n' "${_omb_plugin_kube_ps1_disable_path}" >&2
+        return 1
+      fi
       KUBE_PS1_ENABLED=off ;;
     "")
       KUBE_PS1_ENABLED=off ;;

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -182,10 +182,10 @@ _omb_plugin_kube_ps1_file_newer_than() {
   local file="$1" check_time="$2" mtime
   if stat -c "%s" /dev/null &>/dev/null; then
     # GNU stat
-    mtime=$(stat -L -c %Y "${file}")
+    mtime=$(stat -L -c %Y "${file}" 2>/dev/null) || return 1
   else
     # BSD stat (macOS)
-    mtime=$(stat -L -f %m "${file}")
+    mtime=$(stat -L -f %m "${file}" 2>/dev/null) || return 1
   fi
   (( mtime > check_time ))
 }

--- a/plugins/kube-ps1/kube-ps1.plugin.sh
+++ b/plugins/kube-ps1/kube-ps1.plugin.sh
@@ -379,8 +379,13 @@ kubeoff() {
 # ---------------------------------------------------------------------------
 kube_ps1() {
   [[ "${KUBE_PS1_ENABLED:-on}" == "off" ]] && return
-  [[ -z "${KUBE_PS1_CONTEXT:-}" ]] && [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]] && return
-  [[ "${KUBE_PS1_CONTEXT:-}" == "N/A" ]] && [[ "${KUBE_PS1_HIDE_IF_NOCONTEXT}" == true ]] && return
+  # Normalise empty/absent context to "N/A", then let HIDE_IF_NOCONTEXT decide
+  # whether to show or hide the segment.  Without this, an empty context would
+  # always suppress the segment regardless of HIDE_IF_NOCONTEXT.
+  if [[ "${KUBE_PS1_CONTEXT_ENABLE}" == true ]]; then
+    local KUBE_PS1_CONTEXT="${KUBE_PS1_CONTEXT:-N/A}"
+    [[ "${KUBE_PS1_CONTEXT}" == "N/A" ]] && [[ "${KUBE_PS1_HIDE_IF_NOCONTEXT}" == true ]] && return
+  fi
 
   local reset_color="${_KUBE_PS1_OPEN_ESC}${_KUBE_PS1_DEFAULT_FG}${_KUBE_PS1_CLOSE_ESC}"
   if [[ -n "${KUBE_PS1_BG_COLOR:-}" ]]; then


### PR DESCRIPTION
Closes #719 

## Description

Adds a new `kube-ps1` plugin that displays the current Kubernetes context and
namespace in the shell prompt, with `kubeon` / `kubeoff` commands to toggle it
interactively.

## Changes

- `plugins/kube-ps1/kube-ps1.plugin.sh` — main plugin
- `plugins/kube-ps1/README.md` — documentation and configuration reference
- `plugins/kube-ps1/LICENSE` — Apache 2.0 license from the upstream project (required by its license terms)
- `plugins/README.md` — added `kube-ps1` entry to the plugin table

## Implementation details

- Internal functions and variables follow the `_omb_plugin_kube_ps1_*` naming convention.
- Uses `_omb_util_add_prompt_command()` and `_omb_util_command_exists()` from the OMB API.
- The `kube_ps1` segment is injected into `PS1` via a lazy-registered post-theme hook, so it works correctly regardless of which theme is active — no theme modifications required.
- The kubeconfig files are watched for changes; context/namespace are only re-fetched when a file is actually modified, keeping prompt overhead minimal.
- `kubeon -g` / `kubeoff -g` persist the state across sessions via `~/.kube/kube-ps1/disabled`.

## Usage

```bash
# ~/.bashrc
plugins=(... kube-ps1)
```