### PR TITLE
feat(plugins/gh): add GitHub CLI plugin with aliases and functions

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -24,7 +24,7 @@ You may wish to control when or how plugins are activated. For instance, to ensu
 By leveraging these plugins, you can streamline your workflow and tackle coding challenges with greater efficiency.
 
 | Plugin            | Description                                                                                                                 |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | ansible           | Configuration management tool used to automate the provisioning, configuration, and management of computer systems.         |
 | [asdf](asdf)      | [asdf](https://asdf-vm.com) is a tool version manager to allow installing different versions of Node.js, Ruby, Golang, etc. |
 | aws               | Tools for interacting with Amazon Web Services (AWS)                                                                        |
@@ -57,5 +57,6 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | vagrant           | Tool for creating and managing virtual development environments.                                                            |
 | virtualenvwrapper | A set of extensions to the virtualenv tool.                                                                                 |
 | xterm             | Terminal emulator for X Window systems providing a graphical user interface for accessing the command line.                 |
-| zellij-autoattach | Plugin related to session management in the zellij terminal multiplexer.                                                      |
+| zellij-autoattach | Plugin related to session management in the zellij terminal multiplexer.                                                    |
 | zoxide            | Utility for quickly navigating the filesystem based on visited directory history.                                           |
+| gh                | Aliases and funtions for Github CLI                                                                                         |

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -59,4 +59,4 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | xterm             | Terminal emulator for X Window systems providing a graphical user interface for accessing the command line.                 |
 | zellij-autoattach | Plugin related to session management in the zellij terminal multiplexer.                                                    |
 | zoxide            | Utility for quickly navigating the filesystem based on visited directory history.                                           |
-| gh                | Aliases and funtions for Github CLI                                                                                         |
+| gh                | Convenient aliases for GitHub CLI, providing shortcuts for managing repositories, PRs, issues, releases, and workflows.     |

--- a/plugins/gh/README.md
+++ b/plugins/gh/README.md
@@ -55,6 +55,6 @@ After installation, authenticate with `gh auth login`.
 |-------------------|--------------------------------------------------|-----------------------------------------------|
 | `gh-info`         | Displays `gh` version and authentication status | `gh-info`                                     |
 | `gh-pr-create`    | Creates a pull request with title and optional body, then opens in browser | `gh-pr-create "Title" "Description"` |
-| `gh-issue-list`   | Lsts issues; optional state filter (open/closed) | `gh-issue-list closed`                       |
+| `gh-issue-list`   | Lists issues; optional state filter (open/closed) | `gh-issue-list closed`                       |
 | `gh-repo-clone`   | Clones a repository in `owner/repo` format      | `gh-repo-clone octocat/Hello-World`           |
 | `gh-pr-list`      | Lists pull requests; optional state filter      | `gh-pr-list closed`                           |

--- a/plugins/gh/README.md
+++ b/plugins/gh/README.md
@@ -1,0 +1,60 @@
+  # Oh My Bash Plugin for GitHub CLI (`gh`)
+
+This plugin provides convenient aliases and functions for [GitHub CLI](https://cli.github.com/) (`gh`) when using **Oh My Bash**.
+
+## Prerequisites
+
+You must have GitHub CLI installed. Download it from the official site:
+➡️ **[https://cli.github.com/](https://cli.github.com/)** ⬅️
+
+After installation, authenticate with `gh auth login`.
+
+## Aliases
+
+| Alias    | Command                         | Description                         |
+|----------|---------------------------------|-------------------------------------|
+| `gh`     | `gh`                            | Base command                        |
+| `ghrv`   | `gh repo view`                  | View repository                     |
+| `ghrvw`  | `gh repo view --web`            | View repository in browser          |
+| `ghrc`   | `gh-repo-clone` (function)      | Clone a repository                  |
+| `ghrl`   | `gh repo list`                  | List repositories                   |
+| `ghrel`  | `gh release`                    | Releases base command               |
+| `ghrell` | `gh release list`               | List releases                       |
+| `ghrelc` | `gh release create`             | Create release                      |
+| `ghrelv` | `gh release view`               | View release                        |
+| `ghpr`   | `gh-pr-list` (function)         | List PRs (open by default)          |
+| `ghpro`  | `gh pr list --state open`       | List open PRs                       |
+| `ghprc`  | `gh-pr-create` (function)       | Create a PR                         |
+| `ghprco` | `gh pr checkout`                | Checkout a PR                       |
+| `ghprs`  | `gh pr status`                  | PR status                           |
+| `ghprch` | `gh pr checks`                  | View PR checks                      |
+| `ghprv`  | `gh pr view`                    | View PR                             |
+| `ghprvw` | `gh pr view --web`              | View PR in browser                  |
+| `ghis`   | `gh-issue-list` (function)      | List issues (open by default)       |
+| `ghio`   | `gh issue list --state open`    | List open issues                    |
+| `ghic`   | `gh issue list --state closed`  | List closed issues                  |
+| `ghisc`  | `gh issue create`               | Create issue                        |
+| `ghisv`  | `gh issue view`                 | View issue                          |
+| `ghisvw` | `gh issue view --web`           | View issue in browser               |
+| `ghg`    | `gh gist`                       | Gists base command                  |
+| `ghgl`   | `gh gist list`                  | List gists                          |
+| `ghgc`   | `gh gist create`                | Create gist                         |
+| `ghw`    | `gh workflow`                   | Workflows base command              |
+| `ghwl`   | `gh workflow list`              | List workflows                      |
+| `ghwr`   | `gh workflow run`               | Run workflow                        |
+| `ghwv`   | `gh workflow view`              | View workflow                       |
+| `gha`    | `gh api`                        | Call GitHub API                     |
+| `ghal`   | `gh alias list`                 | List aliases                        |
+| `ghst`   | `gh status`                     | Repository status                   |
+| `ghauth` | `gh auth status`                | Authentication status               |
+| `ghver`  | `gh-info` (function)            | Show version and auth info           |
+
+## Functions
+
+| Function          | Description                                      | Usage Example                                 |
+|-------------------|--------------------------------------------------|-----------------------------------------------|
+| `gh-info`         | Displays `gh` version and authentication status | `gh-info`                                     |
+| `gh-pr-create`    | Creates a pull request with title and optional body, then opens in browser | `gh-pr-create "Title" "Description"` |
+| `gh-issue-list`   | Lsts issues; optional state filter (open/closed) | `gh-issue-list closed`                       |
+| `gh-repo-clone`   | Clones a repository in `owner/repo` format      | `gh-repo-clone octocat/Hello-World`           |
+| `gh-pr-list`      | Lists pull requests; optional state filter      | `gh-pr-list closed`                           |

--- a/plugins/gh/gh.plugin.sh
+++ b/plugins/gh/gh.plugin.sh
@@ -8,10 +8,8 @@
 # -------------------------------------------------------------------------------------------#
 
 
-# Check if gh is installed
 if ! _omb_util_command_exists gh; then
-  _omb_util_print "GitHub CLI (gh) is not installed. Please install it from https://cli.github.com/"
-  return 1
+  _omb_util_print "[oh-my-bash] GitHub CLI (gh) is not installed. Please install it from https://cli.github.com/" >&2
 fi
 
 # Functions
@@ -60,8 +58,6 @@ function gh-pr-list() {
 # Aliases
 
 # Core
-alias gh='gh'
-
 alias ghrv='gh repo view'                    # View repository
 alias ghrvw='gh repo view --web'              # View repository in browser
 alias ghrc='gh-repo-clone'                     # Clone repository (uses function)

--- a/plugins/gh/gh.plugin.sh
+++ b/plugins/gh/gh.plugin.sh
@@ -1,0 +1,105 @@
+#!/bin/bash oh-my-bash.module
+# gh.plugin.bash - Aliases and functions for GitHub CLI
+# Author: Jose2004 (github.com/jose2004)
+
+
+# -------------------------------------------------------------------------------------------#
+# This plugin provides convenient aliases and functions for using the GitHub CLI (gh) tool.
+# -------------------------------------------------------------------------------------------#
+
+
+# Check if gh is installed
+if ! _omb_util_command_exists gh; then
+  _omb_util_print "GitHub CLI (gh) is not installed. Please install it from https://cli.github.com/"
+  return 1
+fi
+
+# Functions
+
+function gh-info() {
+  gh --version
+  echo "---"
+  gh auth status
+}
+
+# Create a pull request with title and optional body
+function gh-pr-create() {
+  if [[ -z "$1" ]]; then
+    _omb_util_print "Usage: gh-pr-create <title> [body]"
+    _omb_util_print "Example: gh-pr-create \"Fix navbar bug\" \"This PR fixes the responsive navbar issue\""
+    return 1
+  fi
+  local title="$1"
+  local body="${2:-}"
+  gh pr create --title "$title" --body "$body" --web
+}
+
+# List issues with optional state filter (open/closed)
+function gh-issue-list() {
+  local state="${1:-open}"
+  gh issue list --state "$state"
+}
+
+# Clone a repository (username/repo format)
+function gh-repo-clone() {
+  if [[ -z "$1" ]]; then
+    _omb_util_print "Usage: gh-repo-clone <repository>"
+    _omb_util_print "Example: gh-repo-clone octocat/Hello-World"
+    return 1
+  fi
+  gh repo clone "$1"
+}
+
+# View and filter pull requests
+function gh-pr-list() {
+  local state="${1:-open}"
+  gh pr list --state "$state"
+}
+
+# --------------------------------------------------------------------------------
+# Aliases
+
+# Core
+alias gh='gh'
+
+alias ghrv='gh repo view'                    # View repository
+alias ghrvw='gh repo view --web'              # View repository in browser
+alias ghrc='gh-repo-clone'                     # Clone repository (uses function)
+alias ghrl='gh repo list'                      # List repositories
+
+alias ghrel='gh release'                       # Releases base command
+alias ghrell='gh release list'                  # List releases
+alias ghrelc='gh release create'                # Create release
+alias ghrelv='gh release view'                  # View release
+
+alias ghpr='gh-pr-list'                         # List PRs (open by default)
+alias ghpro='gh pr list --state open'           # List open PRs
+alias ghprc='gh-pr-create'                       # Create PR (uses function)
+alias ghprco='gh pr checkout'                    # Checkout PR
+alias ghprs='gh pr status'                       # PR status
+alias ghprch='gh pr checks'                      # View PR checks
+alias ghprv='gh pr view'                         # View PR
+alias ghprvw='gh pr view --web'                   # View PR in browser
+
+alias ghis='gh-issue-list'                        # List issues (open by default)
+alias ghio='gh issue list --state open'           # List open issues
+alias ghic='gh issue list --state closed'         # List closed issues
+alias ghisc='gh issue create'                     # Create issue
+alias ghisv='gh issue view'                       # View issue
+alias ghisvw='gh issue view --web'                 # View issue in browser
+
+alias ghg='gh gist'                                # Gists base command
+alias ghgl='gh gist list'                          # List gists
+alias ghgc='gh gist create'                        # Create gist
+
+alias ghw='gh workflow'                            # Workflows base command
+alias ghwl='gh workflow list'                      # List workflows
+alias ghwr='gh workflow run'                       # Run workflow
+alias ghwv='gh workflow view'                       # View workflow
+
+alias gha='gh api'                                 # Call GitHub API
+alias ghal='gh alias list'                         # List aliases
+
+alias ghst='gh status'                             # Repository status
+alias ghauth='gh auth status'                       # Authentication status
+alias ghver='gh-info'                               # Version and auth info (uses function)


### PR DESCRIPTION
## Summary
- Add new plugin for GitHub CLI (gh) with useful aliases and functions
- Includes aliases for common gh commands (pr, issue, repo, run, etc.)
- Provides functions for quick PR creation and viewing

## Changes
- Added plugins/gh/README.md with documentation
- Added plugins/gh/gh.plugin.sh with aliases and functions
- Updated plugins/README.md to include gh plugin