### PR TITLE
fix(plugins/fzf): detect git-installed fzf and add PATH fallback

### DIFF
--- a/plugins/fzf/README.md
+++ b/plugins/fzf/README.md
@@ -7,6 +7,7 @@ The fzf plugin enables [fzf](https://github.com/junegunn/fzf) key bindings and f
 ### Install fzf
 
 **Package manager / mise / asdf:**
+
 ```bash
 # Homebrew
 brew install fzf
@@ -16,6 +17,7 @@ mise use -g fzf
 ```
 
 **Git (official method):**
+
 ```bash
 git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 ~/.fzf/install --no-update-rc  # skip the ~/.bashrc modification, the plugin handles it
@@ -35,7 +37,7 @@ The plugin searches for fzf in the following locations, in order:
 
 1. Already in `$PATH` (package managers, mise, asdf, manual installs)
 2. `~/.fzf/bin` (git clone install)
-3. `~XDG_CONFIG_HOME/fzf/bin`
+3. `${XDG_CONFIG_HOME:-$HOME/.config}/fzf/bin`
 
 ## Key bindings
 

--- a/plugins/fzf/README.md
+++ b/plugins/fzf/README.md
@@ -1,11 +1,48 @@
 # fzf plugin
 
-The fzf plugin enables fzf keybindings and completions on bash.
+The fzf plugin enables [fzf](https://github.com/junegunn/fzf) key bindings and fuzzy completion in Bash.
 
-To use it, install
-[fzf](https://github.com/junegunn/fzf?tab=readme-ov-file#installation) and add fzf
-to the plugins array of your bashrc file:
+## Installation
 
+### Install fzf
+
+**Package manager / mise / asdf:**
 ```bash
-plugins=(... fzf)
+# Homebrew
+brew install fzf
+
+# mise
+mise use -g fzf
 ```
+
+**Git (official method):**
+```bash
+git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
+~/.fzf/install --no-update-rc  # skip the ~/.bashrc modification, the plugin handles it
+```
+
+> **Note:** If you installed fzf via git, pass `--no-update-rc` to the installer (or answer *No* when asked to update `.bashrc`). The plugin automatically adds `~/.fzf/bin` to your `$PATH` — no need for `source ~/.fzf.bash`.
+
+### Enable the plugin
+
+```sh
+plugins=(fzf)
+```
+
+## Supported installation locations
+
+The plugin searches for fzf in the following locations, in order:
+
+1. Already in `$PATH` (package managers, mise, asdf, manual installs)
+2. `~/.fzf/bin` (git clone install)
+3. `~XDG_CONFIG_HOME/fzf/bin`
+
+## Key bindings
+
+Once active, fzf provides these shell key bindings:
+
+| Binding     | Description                                |
+|-------------|--------------------------------------------|
+| `Ctrl+T`    | Paste selected file paths into the command |
+| `Ctrl+R`    | Search command history                     |
+| `Alt+C`     | `cd` into the selected directory           |

--- a/plugins/fzf/fzf.plugin.sh
+++ b/plugins/fzf/fzf.plugin.sh
@@ -27,11 +27,14 @@ if fzf --bash &>/dev/null; then
 else
   # Fallback for fzf < 0.46 git installs
   local _omb_plugin_fzf_base
-  _omb_plugin_fzf_base=$(command -v fzf)
-  _omb_plugin_fzf_base=${_omb_plugin_fzf_base%/bin/fzf}
-  [[ -s $_omb_plugin_fzf_base/shell/key-bindings.bash ]] &&
-    source "$_omb_plugin_fzf_base/shell/key-bindings.bash"
-  [[ $- == *i* && -s $_omb_plugin_fzf_base/shell/completion.bash ]] &&
-    source "$_omb_plugin_fzf_base/shell/completion.bash"
+  _omb_plugin_fzf_base=$(command -v fzf 2>/dev/null)
+  # Ensure we got a real filesystem path, not a function/alias name
+  if [[ -x $_omb_plugin_fzf_base ]]; then
+    _omb_plugin_fzf_base=${_omb_plugin_fzf_base%/bin/fzf}
+    [[ -s $_omb_plugin_fzf_base/shell/key-bindings.bash ]] &&
+      source "$_omb_plugin_fzf_base/shell/key-bindings.bash"
+    [[ $- == *i* && -s $_omb_plugin_fzf_base/shell/completion.bash ]] &&
+      source "$_omb_plugin_fzf_base/shell/completion.bash"
+  fi
   unset -v _omb_plugin_fzf_base
 fi

--- a/plugins/fzf/fzf.plugin.sh
+++ b/plugins/fzf/fzf.plugin.sh
@@ -1,9 +1,37 @@
 #! bash oh-my-bash.module
+# Description: Integrate fzf (https://github.com/junegunn/fzf) key bindings and fuzzy completion
 
-# Check if fzf is installed
-if _omb_util_command_exists fzf; then
-  # Set up fzf key bindings and fuzzy completion
-  eval -- "$(fzf --bash)"
-else
+# -- Locate fzf ---------------------------------------------------------------
+# Support common installation methods:
+#   1. Already in $PATH (package manager, mise/asdf, manual)
+#   2. Git install: ~/.fzf/bin
+#   3. XDG config dir: ~/.config/fzf/bin (less common)
+if ! _omb_util_command_exists fzf; then
+  if [[ -x $HOME/.fzf/bin/fzf ]]; then
+    PATH="${PATH:+$PATH:}$HOME/.fzf/bin"
+  elif [[ -x ${XDG_CONFIG_HOME:-$HOME/.config}/fzf/bin/fzf ]]; then
+    PATH="${PATH:+$PATH:}${XDG_CONFIG_HOME:-$HOME/.config}/fzf/bin"
+  fi
+fi
+
+if ! _omb_util_command_exists fzf; then
   _omb_util_print '[oh-my-bash] fzf not found, please install it from https://github.com/junegunn/fzf' >&2
+  return
+fi
+
+# -- Activate -----------------------------------------------------------------
+# fzf >= 0.46 ships `fzf --bash` which emits key bindings + completions in one go.
+# Older git installs ship separate shell scripts under ~/.fzf/shell/.
+if fzf --bash &>/dev/null; then
+  eval "$(fzf --bash)"
+else
+  # Fallback for fzf < 0.46 git installs
+  local _omb_plugin_fzf_base
+  _omb_plugin_fzf_base=$(command -v fzf)
+  _omb_plugin_fzf_base=${_omb_plugin_fzf_base%/bin/fzf}
+  [[ -s $_omb_plugin_fzf_base/shell/key-bindings.bash ]] &&
+    source "$_omb_plugin_fzf_base/shell/key-bindings.bash"
+  [[ $- == *i* && -s $_omb_plugin_fzf_base/shell/completion.bash ]] &&
+    source "$_omb_plugin_fzf_base/shell/completion.bash"
+  unset -v _omb_plugin_fzf_base
 fi


### PR DESCRIPTION
**Documentation improvements:**

* Expanded and clarified the `plugins/fzf/README.md` to include detailed installation instructions for multiple methods (package manager, mise/asdf, git), plugin activation steps, supported search locations, and a table of available key bindings.

**Plugin compatibility and setup:**

* Updated `plugins/fzf/fzf.plugin.sh` to automatically detect `fzf` in common install locations (`$PATH`, `~/.fzf/bin`, and `~/.config/fzf/bin`), improving support for various installation methods.
* Enhanced plugin activation logic to use `fzf --bash` for versions ≥0.46 (which sets up key bindings and completions in one step), and gracefully fall back to sourcing legacy shell scripts for older git-based installs.
* Improved error messaging when `fzf` is not found, guiding the user to installation resources.