### PR TITLE
feat(plugins/mise): add mise plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -45,6 +45,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | golang            | The Go programming language, along with its tools and standard libraries.                                                   |
 | jump              | Jump helps you navigate faster by learning your habits.                                                                     |
 | kubectl           | Command-line tool for interacting with Kubernetes clusters.                                                                 |
+| [mise](mise)      | [mise](https://mise.jdx.dev) is a polyglot tool version manager for Node.js, Python, Ruby, Go, and more.                    |
 | npm               | Package manager for Node.js facilitating installation and management of project dependencies.                               |
 | nvm               | Node.js version manager allowing easy switching between different Node.js versions.                                         |
 | progress          | Insufficient information provided to give a precise description.                                                            |

--- a/plugins/mise/README.md
+++ b/plugins/mise/README.md
@@ -1,0 +1,54 @@
+# mise plugin
+
+Add [oh-my-bash](https://ohmybash.github.io) integration with [mise](https://mise.jdx.dev), a polyglot tool version manager for Node.js, Python, Ruby, Go, and more. mise is a faster, drop-in replacement for [asdf](https://asdf-vm.com) that also supports `.tool-versions` files.
+
+## Installation
+
+1. [Install mise](https://mise.jdx.dev/getting-started.html) by running the following:
+
+    ```bash
+    curl https://mise.run | sh
+    ```
+
+2. Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.bashrc`.
+
+    ```sh
+    plugins=(mise)
+    ```
+
+The plugin resolves the mise binary automatically — no manual `eval` line in `~/.bashrc` is needed. It checks the following locations in order:
+
+1. `mise` on `$PATH` (system package managers: apt, brew, dnf, pacman, etc.)
+2. `$MISE_INSTALL_PATH` (custom install path set at install time)
+3. `~/.local/bin/mise` (default location for `curl https://mise.run | sh`)
+
+## Configuration
+
+### Quiet mode
+
+By default, mise may print a message when activated. To suppress this, set the following variable **before** the `source` line in your `~/.bashrc`:
+
+```sh
+OMB_PLUGIN_MISE_QUIET=true
+```
+
+## Aliases
+
+| Alias  | Command           | Description                              |
+|--------|-------------------|------------------------------------------|
+| `mi`   | `mise install`    | Install tool versions defined in config  |
+| `mu`   | `mise use`        | Set a tool version in the config file    |
+| `mr`   | `mise run`        | Run a task defined in `mise.toml`        |
+| `mex`  | `mise exec`       | Run a command in the mise environment    |
+| `mls`  | `mise ls`         | List installed tool versions             |
+| `mlsr` | `mise ls-remote`  | List available remote versions           |
+
+## Usage
+
+See the [mise documentation](https://mise.jdx.dev/getting-started.html) for full usage:
+
+```bash
+mi node@22          # mise install node@22
+mu node@lts         # mise use node@lts
+mex -- node --version
+```

--- a/plugins/mise/mise.plugin.sh
+++ b/plugins/mise/mise.plugin.sh
@@ -1,0 +1,32 @@
+#! bash oh-my-bash.module
+# Description: Integrate mise (https://mise.jdx.dev), a polyglot tool version manager
+#
+# @var[opt] OMB_PLUGIN_MISE_QUIET set to 'true' to suppress mise activation output
+
+# Resolve the mise binary: check PATH first, then the default install location
+# used by the official installer (curl https://mise.run | sh), then any custom
+# install path set via MISE_INSTALL_PATH.
+_omb_plugin_mise_bin=
+if _omb_util_command_exists mise; then
+  _omb_plugin_mise_bin=mise
+elif [[ -x "${MISE_INSTALL_PATH:-}" ]]; then
+  _omb_plugin_mise_bin=$MISE_INSTALL_PATH
+elif [[ -x "$HOME/.local/bin/mise" ]]; then
+  _omb_plugin_mise_bin=$HOME/.local/bin/mise
+fi
+
+if [[ -n $_omb_plugin_mise_bin ]]; then
+  if [[ ${OMB_PLUGIN_MISE_QUIET-} == true ]]; then
+    eval "$("$_omb_plugin_mise_bin" activate bash --quiet)"
+  else
+    eval "$("$_omb_plugin_mise_bin" activate bash)"
+  fi
+
+  alias mi='mise install'
+  alias mu='mise use'
+  alias mr='mise run'
+  alias mex='mise exec'
+  alias mls='mise ls'
+  alias mlsr='mise ls-remote'
+fi
+unset _omb_plugin_mise_bin


### PR DESCRIPTION
* Added a new `mise` plugin, providing integration with the `mise` polyglot tool version manager, including support for quiet mode and common command aliases. (`plugins/mise/mise.plugin.sh`, [plugins/mise/mise.plugin.shR1-R19](diffhunk://#diff-9bd905beb507b1c04900d5acad71b0ea587e8352bd33f8d34e7b2fc0071752f6R1-R19))
* Created a comprehensive README for the `mise` plugin, detailing installation, configuration, available aliases, and usage examples. (`plugins/mise/README.md`, [plugins/mise/README.mdR1-R46](diffhunk://#diff-d9126adc8a1e5eeada944543b1e49befb000f2e2e043ea63e32d85ee0753cbedR1-R46))
* Updated the main plugins list to include `mise` with a description and link for easy discovery. (`plugins/README.md`, [plugins/README.mdR48](diffhunk://#diff-8b2fec43efe67316d27984b7b6fe79569fa2e61ffdd6ed811aa114e29338b860R48))