### PR TITLE
feat(plugins/docker): add docker plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -36,6 +36,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | cargo             | Plugin to initialize CARGO_HOME and PATH for cargo                                                                          |
 | colored-man-pages | Adds a few colors to `man` pages.                                                                                           |
 | chezmoi           | Dotfile management tool enabling management of user environment configuration.                                              |
+| [docker](docker)  | Aliases and utility functions for [Docker](https://www.docker.com/).                                                        |
 | dotnet            | This plugin provides completion and useful aliases for .NET Core CLI.                                                       |
 | fasd              | Utility easing filesystem navigation through shortcuts and abbreviated commands.                                            |
 | fzf               | A command-line fuzzy finder.                                                                                                |
@@ -57,5 +58,5 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | vagrant           | Tool for creating and managing virtual development environments.                                                            |
 | virtualenvwrapper | A set of extensions to the virtualenv tool.                                                                                 |
 | xterm             | Terminal emulator for X Window systems providing a graphical user interface for accessing the command line.                 |
-| zellij-autoattach | Plugin related to session management in the zellij terminal multiplexer.                                                      |
+| zellij-autoattach | Plugin related to session management in the zellij terminal multiplexer.                                                    |
 | zoxide            | Utility for quickly navigating the filesystem based on visited directory history.                                           |

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -1,0 +1,122 @@
+# docker plugin
+
+Add [oh-my-bash](https://ohmybash.github.io) integration with [Docker](https://www.docker.com/), providing aliases and utility functions for common Docker workflows. Inspired by the [oh-my-zsh docker plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/docker).
+
+## Installation
+
+1. [Install Docker](https://docs.docker.com/get-docker/).
+
+2. Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.bashrc`.
+    ```sh
+    plugins=(docker)
+    ```
+
+3. Optionally, enable Docker tab completions by adding it to your `completions` definition:
+    ```sh
+    completions=(docker)
+    ```
+
+## Aliases
+
+### Build
+
+| Alias  | Command               | Description                            |
+|--------|-----------------------|----------------------------------------|
+| `dbl`  | `docker build`        | Build an image from a Dockerfile       |
+
+### Containers
+
+| Alias   | Command                      | Description                                          |
+|---------|------------------------------|------------------------------------------------------|
+| `dcin`  | `docker container inspect`   | Display detailed info on one or more containers      |
+| `dcls`  | `docker container ls`        | List running containers                              |
+| `dclsa` | `docker container ls -a`     | List all containers (running and stopped)            |
+| `dlo`   | `docker container logs`      | Fetch the logs of a container                        |
+| `dpo`   | `docker container port`      | List port mappings for a container                   |
+| `dr`    | `docker container run`       | Create and start a container                         |
+| `drit`  | `docker container run -it`   | Create and start a container interactively           |
+| `drm`   | `docker container rm`        | Remove one or more containers                        |
+| `drmf`  | `docker container rm -f`     | Force-remove a running container                     |
+| `drs`   | `docker container restart`   | Restart one or more containers                       |
+| `dst`   | `docker container start`     | Start one or more stopped containers                 |
+| `dstp`  | `docker container stop`      | Stop one or more running containers                  |
+| `dsts`  | `docker stats`               | Display real-time container resource usage           |
+| `dtop`  | `docker top`                 | Display the running processes of a container         |
+| `dxc`   | `docker container exec`      | Run a command in a running container                 |
+| `dxcit` | `docker container exec -it`  | Run an interactive command in a running container    |
+
+### Images
+
+| Alias    | Command                  | Description                                      |
+|----------|--------------------------|--------------------------------------------------|
+| `dib`    | `docker image build`     | Build an image from a Dockerfile                 |
+| `dii`    | `docker image inspect`   | Display detailed info on one or more images      |
+| `dils`   | `docker image ls`        | List images                                      |
+| `dipru`  | `docker image prune -a`  | Remove all unused images                         |
+| `dipu`   | `docker image push`      | Push an image to a registry                      |
+| `dirm`   | `docker image rm`        | Remove one or more images                        |
+| `dit`    | `docker image tag`       | Tag an image                                     |
+| `dpu`    | `docker pull`            | Pull an image from a registry                    |
+
+### Networks
+
+| Alias   | Command                       | Description                            |
+|---------|-------------------------------|----------------------------------------|
+| `dnc`   | `docker network create`       | Create a network                       |
+| `dncn`  | `docker network connect`      | Connect a container to a network       |
+| `dndcn` | `docker network disconnect`   | Disconnect a container from a network  |
+| `dni`   | `docker network inspect`      | Display detailed info on a network     |
+| `dnls`  | `docker network ls`           | List networks                          |
+| `dnrm`  | `docker network rm`           | Remove one or more networks            |
+
+### Volumes
+
+| Alias     | Command                | Description                         |
+|-----------|------------------------|-------------------------------------|
+| `dvi`     | `docker volume inspect`| Display detailed info on a volume   |
+| `dvls`    | `docker volume ls`     | List volumes                        |
+| `dvprune` | `docker volume prune`  | Remove unused volumes               |
+
+### General
+
+| Alias  | Command        | Description                                |
+|--------|----------------|--------------------------------------------|
+| `dps`  | `docker ps`    | List running containers                    |
+| `dpsa` | `docker ps -a` | List all containers                        |
+
+### System
+
+| Alias   | Command                    | Description                                 |
+|---------|----------------------------|---------------------------------------------|
+| `dsi`   | `docker system info`       | Display system-wide information             |
+| `dsdf`  | `docker system df`         | Show Docker disk usage                      |
+| `dsp`   | `docker system prune`      | Remove unused data (with confirmation)      |
+| `dspf`  | `docker system prune -f`   | Remove unused data (no confirmation prompt) |
+| `dspa`  | `docker system prune -a`   | Remove all unused data including images     |
+
+## Utility functions
+
+| Alias   | Description                                                      |
+|---------|------------------------------------------------------------------|
+| `dsta`  | Stop all running containers                                      |
+| `drmst` | Remove all stopped containers                                    |
+| `dip`   | Print the IP address of a container: `dip <container>`          |
+
+## Usage examples
+
+```bash
+# Start an interactive Ubuntu container and remove it on exit
+drit --rm ubuntu bash
+
+# Tail logs of a running container
+dlo -f my-container
+
+# Get the IP address of a container
+dip my-container
+
+# Stop all running containers
+dsta
+
+# Clean up stopped containers and dangling images
+drmst && dsp
+```

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -7,14 +7,12 @@ Add [oh-my-bash](https://ohmybash.github.io) integration with [Docker](https://w
 1. [Install Docker](https://docs.docker.com/get-docker/).
 
 2. Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.bashrc`.
+
     ```sh
     plugins=(docker)
     ```
 
-3. Optionally, enable Docker tab completions by adding it to your `completions` definition:
-    ```sh
-    completions=(docker)
-    ```
+> **Note:** Tab completion for Docker commands is included automatically — no separate `completions=(docker)` entry is needed.
 
 ## Aliases
 

--- a/plugins/docker/docker.plugin.sh
+++ b/plugins/docker/docker.plugin.sh
@@ -2,11 +2,11 @@
 # Description: Aliases and utility functions for Docker
 # Inspired by the oh-my-zsh docker plugin (https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/docker)
 
-_omb_module_require completion:docker
-
 if ! _omb_util_command_exists docker; then
   return
 fi
+
+_omb_module_require completion:docker
 
 # Build
 alias dbl='docker build'
@@ -75,10 +75,13 @@ function _omb_plugin_docker_stop_all {
 }
 alias dsta='_omb_plugin_docker_stop_all'
 
-# Remove all stopped containers
+# Remove all stopped containers (created, paused, exited, dead)
 function _omb_plugin_docker_rm_stopped {
   local -a ids
-  ids=($(docker ps -aq --filter status=exited)) || return 1
+  ids=($(docker ps -aq --filter status=created \
+                          --filter status=paused \
+                          --filter status=exited \
+                          --filter status=dead)) || return 1
   if [[ ${#ids[@]} -eq 0 ]]; then
     _omb_util_print '[oh-my-bash] docker: no stopped containers to remove' >&2
     return 0

--- a/plugins/docker/docker.plugin.sh
+++ b/plugins/docker/docker.plugin.sh
@@ -1,0 +1,94 @@
+#! bash oh-my-bash.module
+# Description: Aliases and utility functions for Docker
+# Inspired by the oh-my-zsh docker plugin (https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/docker)
+
+_omb_module_require completion:docker
+
+if ! _omb_util_command_exists docker; then
+  return
+fi
+
+# Build
+alias dbl='docker build'
+
+# Containers
+alias dcin='docker container inspect'
+alias dcls='docker container ls'
+alias dclsa='docker container ls -a'
+alias dlo='docker container logs'
+alias dpo='docker container port'
+alias dr='docker container run'
+alias drit='docker container run -it'
+alias drm='docker container rm'
+alias drmf='docker container rm -f'
+alias drs='docker container restart'
+alias dst='docker container start'
+alias dstp='docker container stop'
+alias dsts='docker stats'
+alias dtop='docker top'
+alias dxc='docker container exec'
+alias dxcit='docker container exec -it'
+
+# Images
+alias dib='docker image build'
+alias dii='docker image inspect'
+alias dils='docker image ls'
+alias dipru='docker image prune -a'
+alias dipu='docker image push'
+alias dirm='docker image rm'
+alias dit='docker image tag'
+alias dpu='docker pull'
+
+# Networks
+alias dnc='docker network create'
+alias dncn='docker network connect'
+alias dndcn='docker network disconnect'
+alias dni='docker network inspect'
+alias dnls='docker network ls'
+alias dnrm='docker network rm'
+
+# Volumes
+alias dvi='docker volume inspect'
+alias dvls='docker volume ls'
+alias dvprune='docker volume prune'
+
+# General
+alias dps='docker ps'
+alias dpsa='docker ps -a'
+
+# System
+alias dsi='docker system info'
+alias dsdf='docker system df'
+alias dsp='docker system prune'
+alias dspf='docker system prune -f'
+alias dspa='docker system prune -a'
+
+# Stop all running containers
+function _omb_plugin_docker_stop_all {
+  local -a ids
+  ids=($(docker ps -q)) || return 1
+  if [[ ${#ids[@]} -eq 0 ]]; then
+    _omb_util_print '[oh-my-bash] docker: no running containers to stop' >&2
+    return 0
+  fi
+  docker stop "${ids[@]}"
+}
+alias dsta='_omb_plugin_docker_stop_all'
+
+# Remove all stopped containers
+function _omb_plugin_docker_rm_stopped {
+  local -a ids
+  ids=($(docker ps -aq --filter status=exited)) || return 1
+  if [[ ${#ids[@]} -eq 0 ]]; then
+    _omb_util_print '[oh-my-bash] docker: no stopped containers to remove' >&2
+    return 0
+  fi
+  docker rm "${ids[@]}"
+}
+alias drmst='_omb_plugin_docker_rm_stopped'
+
+# Print the IP address of a container: dip <container>
+function _omb_plugin_docker_ip {
+  docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$@"
+}
+alias dip='_omb_plugin_docker_ip'


### PR DESCRIPTION
**New Docker Plugin Integration:**

* Added a new entry for the Docker plugin in the main plugins list in `README.md`, linking to its documentation.

**Documentation:**

* Created `plugins/docker/README.md` with detailed installation instructions, a complete list of aliases, descriptions of utility functions, and usage examples for the Docker plugin.

**Plugin Implementation:**

* Added `plugins/docker/docker.plugin.sh`, which defines a wide range of Docker command aliases (for containers, images, networks, volumes, and system operations) and implements utility functions such as stopping all running containers (`dsta`), removing all stopped containers (`drmst`), and retrieving a container's IP address (`dip`).