### PR TITLE
feat(plugins/golang): enhance aliases and add utility functions

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -42,7 +42,7 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | gcloud            | Command-line tools for interacting with Google Cloud Platform (GCP).                                                        |
 | git               | Distributed version control system for managing the history of changes in software projects.                                |
 | goenv             | Tool for managing Go versions within a development environment.                                                             |
-| golang            | The Go programming language, along with its tools and standard libraries.                                                   |
+| [golang](golang)  | Aliases and utilities for Go development, including build, test, mod, and coverage helpers.                                 |
 | jump              | Jump helps you navigate faster by learning your habits.                                                                     |
 | kubectl           | Command-line tool for interacting with Kubernetes clusters.                                                                 |
 | npm               | Package manager for Node.js facilitating installation and management of project dependencies.                               |

--- a/plugins/golang/README.md
+++ b/plugins/golang/README.md
@@ -1,29 +1,125 @@
-# Golang plugin
+# golang plugin
 
-The `golang plugin` plugin adds some aliases for common [Golang](https://golang.org/) commands.
+Add [oh-my-bash](https://ohmybash.github.io) integration for [Go](https://golang.org/) development, providing aliases and utility functions for common Go workflows. Inspired by the [oh-my-zsh golang plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/golang).
 
-To use it, add `golang` to the plugins array of your bashrc file:
+## Installation
 
+Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.bashrc`.
+
+```sh
+plugins=(golang)
 ```
-plugins=(... golang)
+
+Optionally, enable Go tab completions:
+
+```sh
+completions=(go)
 ```
 
 ## Aliases
 
-| Alias   | Command                 | Description                                                   |
-| ------- | ----------------------- | ------------------------------------------------------------- |
-| gob     | `go build`              | Build your code                                               |
-| goc     | `go clean`              | Removes object files from package source directories          |
-| god     | `go doc`                | Prints documentation comments                                 |
-| gof     | `go fmt`                | Gofmt formats (aligns and indents) Go programs.               |
-| gofa    | `go fmt ./...`          | Run go fmt for all packages in current directory, recursively |
-| gog     | `go get`                | Downloads packages and then installs them to $GOPATH          |
-| goi     | `go install`            | Compiles and installs packages to $GOPATH                     |
-| gol     | `go list`               | Lists Go packages                                             |
-| gom     | `go mod`                | Access to operations on modules                               |
-| gop     | `cd $GOPATH`            | Takes you to $GOPATH                                          |
-| gopb    | `cd $GOPATH/bin`        | Takes you to $GOPATH/bin                                      |
-| gops    | `cd $GOPATH/src`        | Takes you to $GOPATH/src                                      |
-| gor     | `go run`                | Compiles and runs your code                                   |
-| got     | `go test`               | Runs tests                                                    |
-| gov     | `go vet`                | Vet examines Go source code and reports suspicious constructs |
+### Build
+
+| Alias  | Command          | Description                              |
+|--------|------------------|------------------------------------------|
+| `gob`  | `go build`       | Build the current package                |
+| `goba` | `go build ./...` | Build all packages recursively           |
+
+### Clean
+
+| Alias | Command    | Description                              |
+|-------|------------|------------------------------------------|
+| `goc` | `go clean` | Remove object files and cached files     |
+
+### Doc / Env / Fix
+
+| Alias  | Command    | Description                              |
+|--------|------------|------------------------------------------|
+| `god`  | `go doc`   | Show documentation for a package/symbol  |
+| `goe`  | `go env`   | Print Go environment information         |
+| `gofx` | `go fix`   | Update packages to use new APIs          |
+
+### Format
+
+| Alias  | Command          | Description                              |
+|--------|------------------|------------------------------------------|
+| `gof`  | `go fmt`         | Format the current package               |
+| `gofa` | `go fmt ./...`   | Format all packages recursively          |
+
+### Get / Install
+
+| Alias  | Command          | Description                                     |
+|--------|------------------|-------------------------------------------------|
+| `gog`  | `go get`         | Download and install packages                   |
+| `goga` | `go get ./...`   | Download and install all packages recursively   |
+| `goi`  | `go install`     | Compile and install packages to `$GOPATH`       |
+
+### List / Mod
+
+| Alias  | Command            | Description                              |
+|--------|--------------------|------------------------------------------|
+| `gol`  | `go list`          | List packages or modules                 |
+| `gom`  | `go mod`           | Module maintenance                       |
+| `gomt` | `go mod tidy`      | Add missing and remove unused modules    |
+| `gomi` | `go mod init`      | Initialize a new module                  |
+| `gomv` | `go mod vendor`    | Make a vendored copy of dependencies     |
+
+### Run
+
+| Alias | Command  | Description                     |
+|-------|----------|---------------------------------|
+| `gor` | `go run` | Compile and run a Go program    |
+
+### Test
+
+| Alias   | Command              | Description                              |
+|---------|----------------------|------------------------------------------|
+| `got`   | `go test`            | Run tests                                |
+| `gota`  | `go test ./...`      | Run all tests recursively                |
+| `gotv`  | `go test -v`         | Run tests with verbose output            |
+| `gotva` | `go test -v ./...`   | Run all tests recursively with verbosity |
+
+### Tool
+
+| Alias    | Command              | Description                              |
+|----------|----------------------|------------------------------------------|
+| `goto`   | `go tool`            | Run a specific Go tool                   |
+| `gotoc`  | `go tool compile`    | Compile Go source files                  |
+| `gotod`  | `go tool dist`       | Bootstrap and distribution tool          |
+| `gotofx` | `go tool fix`        | Find and fix outdated API usage          |
+
+### Vet / Version / Work
+
+| Alias  | Command        | Description                              |
+|--------|----------------|------------------------------------------|
+| `gov`  | `go vet`       | Report suspicious code constructs        |
+| `gova` | `go vet ./...` | Vet all packages recursively             |
+| `gove` | `go version`   | Print the current Go version             |
+| `gow`  | `go work`      | Workspace maintenance                    |
+
+### Navigation
+
+| Alias  | Command             | Description                          |
+|--------|---------------------|--------------------------------------|
+| `gop`  | `cd $GOPATH`        | Go to `$GOPATH`                      |
+| `gopb` | `cd $GOPATH/bin`    | Go to `$GOPATH/bin`                  |
+| `gops` | `cd $GOPATH/src`    | Go to `$GOPATH/src`                  |
+
+## Utility functions
+
+### `gocd <package>`
+
+Navigate to a package's source directory under `$GOPATH/src`.
+
+```bash
+gocd github.com/some/package
+```
+
+### `gocov [go test flags]`
+
+Run tests with a coverage report and open the result in your browser. Accepts the same flags as `go test`; defaults to `./...`.
+
+```bash
+gocov              # test all packages + open coverage report
+gocov ./pkg/...    # test a specific subtree
+```

--- a/plugins/golang/README.md
+++ b/plugins/golang/README.md
@@ -10,11 +10,7 @@ Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.ba
 plugins=(golang)
 ```
 
-Optionally, enable Go tab completions:
-
-```sh
-completions=(go)
-```
+> **Note:** Tab completion for Go commands is included automatically — no separate `completions=(go)` entry is needed.
 
 ## Aliases
 
@@ -109,17 +105,19 @@ completions=(go)
 
 ### `gocd <package>`
 
-Navigate to a package's source directory under `$GOPATH/src`.
+Navigate to a package's source directory under `$GOPATH/src`. Prints a clear error if `GOPATH` is not set.
 
 ```bash
 gocd github.com/some/package
 ```
 
-### `gocov [go test flags]`
+### `gocov [-flags...] [packages]`
 
-Run tests with a coverage report and open the result in your browser. Accepts the same flags as `go test`; defaults to `./...`.
+Run tests with a coverage report and open the result in your browser. Flags (arguments starting with `-`) are forwarded to `go test`; remaining arguments are treated as packages. If no packages are given, `./...` is used as the default.
 
 ```bash
-gocov              # test all packages + open coverage report
-gocov ./pkg/...    # test a specific subtree
+gocov                      # test ./... + open coverage report
+gocov ./pkg/...            # test a specific subtree
+gocov -run=TestFoo         # run a specific test across ./...
+gocov -run=TestFoo ./pkg/... # run a specific test in a subtree
 ```

--- a/plugins/golang/golang.plugin.sh
+++ b/plugins/golang/golang.plugin.sh
@@ -1,17 +1,103 @@
 #! bash oh-my-bash.module
+# Description: Aliases and utilities for Go development
+# Inspired by the oh-my-zsh golang plugin (https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/golang)
 
+_omb_module_require completion:go
+
+if ! _omb_util_command_exists go; then
+  return
+fi
+
+# Build
 alias gob='go build'
+alias goba='go build ./...'
+
+# Clean
 alias goc='go clean'
+
+# Doc
 alias god='go doc'
+
+# Env
+alias goe='go env'
+
+# Fix
+alias gofx='go fix'
+
+# Format
 alias gof='go fmt'
 alias gofa='go fmt ./...'
+
+# Get
 alias gog='go get'
+alias goga='go get ./...'
+
+# Install
 alias goi='go install'
+
+# List
 alias gol='go list'
+
+# Mod
 alias gom='go mod'
+alias gomt='go mod tidy'
+alias gomi='go mod init'
+alias gomv='go mod vendor'
+
+# Run
+alias gor='go run'
+
+# Test
+alias got='go test'
+alias gota='go test ./...'
+alias gotv='go test -v'
+alias gotva='go test -v ./...'
+
+# Tool
+alias goto='go tool'
+alias gotoc='go tool compile'
+alias gotod='go tool dist'
+alias gotofx='go tool fix'
+
+# Vet
+alias gov='go vet'
+alias gova='go vet ./...'
+
+# Version
+alias gove='go version'
+
+# Work
+alias gow='go work'
+
+# Navigate to $GOPATH
 alias gop='cd $GOPATH'
 alias gopb='cd $GOPATH/bin'
 alias gops='cd $GOPATH/src'
-alias gor='go run'
-alias got='go test'
-alias gov='go vet'
+
+#------------------------------------------------------------------------------
+# Utility functions
+
+# Navigate to a package's source directory under $GOPATH/src.
+# Usage: gocd <package>
+function _omb_plugin_golang_cd {
+  local pkg=$1
+  if [[ -z $pkg ]]; then
+    _omb_util_print 'gocd: usage: gocd <package>' >&2
+    return 1
+  fi
+  local gopath
+  gopath=$(go env GOPATH)
+  cd "$gopath/src/$pkg" || return $?
+}
+alias gocd='_omb_plugin_golang_cd'
+
+# Run tests with a coverage report opened in the browser.
+# Usage: gocov [go test flags] (defaults to ./...)
+function _omb_plugin_golang_cov {
+  local coverfile
+  coverfile=$(mktemp /tmp/go-cover-XXXXXX.out)
+  go test -coverprofile="$coverfile" "${@:-./...}" || { rm -f "$coverfile"; return $?; }
+  go tool cover -html="$coverfile"
+  rm -f "$coverfile"
+}
+alias gocov='_omb_plugin_golang_cov'

--- a/plugins/golang/golang.plugin.sh
+++ b/plugins/golang/golang.plugin.sh
@@ -2,11 +2,11 @@
 # Description: Aliases and utilities for Go development
 # Inspired by the oh-my-zsh golang plugin (https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/golang)
 
-_omb_module_require completion:go
-
 if ! _omb_util_command_exists go; then
   return
 fi
+
+_omb_module_require completion:go
 
 # Build
 alias gob='go build'
@@ -87,17 +87,35 @@ function _omb_plugin_golang_cd {
   fi
   local gopath
   gopath=$(go env GOPATH)
+  if [[ -z $gopath ]]; then
+    _omb_util_print 'gocd: GOPATH is not set or empty' >&2
+    return 1
+  fi
   cd "$gopath/src/$pkg" || return $?
 }
 alias gocd='_omb_plugin_golang_cd'
 
 # Run tests with a coverage report opened in the browser.
-# Usage: gocov [go test flags] (defaults to ./...)
+# Usage: gocov [-go-test-flags...] [packages] (defaults to ./...)
+# Flags (args starting with -) are passed to go test; remaining args are
+# treated as packages. If no packages are given, ./... is used as default.
 function _omb_plugin_golang_cov {
-  local coverfile
-  coverfile=$(mktemp /tmp/go-cover-XXXXXX.out)
-  go test -coverprofile="$coverfile" "${@:-./...}" || { rm -f "$coverfile"; return $?; }
+  local arg flag_args=() pkg_args=()
+  for arg in "$@"; do
+    if [[ $arg == -* ]]; then
+      flag_args+=("$arg")
+    else
+      pkg_args+=("$arg")
+    fi
+  done
+  [[ ${#pkg_args[@]} -eq 0 ]] && pkg_args=(./...)
+
+  local coverfile rc
+  coverfile=$(_omb_util_mktemp) || return 1
+  go test -coverprofile="$coverfile" "${flag_args[@]}" "${pkg_args[@]}" || { rm -f "$coverfile"; return $?; }
   go tool cover -html="$coverfile"
+  rc=$?
   rm -f "$coverfile"
+  return $rc
 }
 alias gocov='_omb_plugin_golang_cov'


### PR DESCRIPTION
**Plugin enhancements and new features:**

* Added many new aliases for Go commands covering build, test, module management, formatting, vetting, and navigation, making it easier to run common Go tasks from the command line.
* Introduced utility functions:
  * [`gocd <package>`](diffhunk://#diff-cf0125ba8dcd7addb6dd725b4943cdd570048d86bdce6ed30e32d3388e7e28ffR2-R103): Quickly navigate to a Go package's source directory.
  * [`gocov [go test flags]`](diffhunk://#diff-cf0125ba8dcd7addb6dd725b4943cdd570048d86bdce6ed30e32d3388e7e28ffR2-R103): Run tests with coverage reporting and open the results in a browser.

**Documentation improvements:**

* Rewrote and expanded `plugins/golang/README.md` to include detailed installation instructions, a comprehensive list of aliases grouped by theme, and documentation for the new utility functions.
* Updated the main `plugins/README.md` to clarify the purpose of the `golang` plugin and link to its documentation.