### PR TITLE
feat(plugins): add node plugin and enhance npm plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -45,7 +45,8 @@ By leveraging these plugins, you can streamline your workflow and tackle coding 
 | golang            | The Go programming language, along with its tools and standard libraries.                                                   |
 | jump              | Jump helps you navigate faster by learning your habits.                                                                     |
 | kubectl           | Command-line tool for interacting with Kubernetes clusters.                                                                 |
-| npm               | Package manager for Node.js facilitating installation and management of project dependencies.                               |
+| [node](node)      | Aliases and utilities for Node.js development, including API docs browser integration.                                      |
+| [npm](npm)        | Package manager for Node.js facilitating installation and management of project dependencies.                               |
 | nvm               | Node.js version manager allowing easy switching between different Node.js versions.                                         |
 | progress          | Insufficient information provided to give a precise description.                                                            |
 | pyenv             | Tool for managing multiple Python versions within a system.                                                                 |

--- a/plugins/node/README.md
+++ b/plugins/node/README.md
@@ -36,7 +36,8 @@ Works with any Node.js version manager (nvm, mise, asdf, etc.) — it always ref
 Evaluate a JavaScript expression via `node -e` and pretty-print the result as JSON. Useful for quickly inspecting Node.js internals.
 
 ```bash
-node-json 'process.versions'   # print all runtime versions
-node-json 'process.env'        # print environment variables
-node-json 'os.cpus().length'   # requires: const os = require("os")
+node-json 'process.versions'            # print all runtime versions
+node-json 'process.env'                 # print environment variables
+node-json 'require("os").cpus()'        # print CPU info (using require)
+node-json 'require("os").cpus().length' # number of CPUs
 ```

--- a/plugins/node/README.md
+++ b/plugins/node/README.md
@@ -1,0 +1,42 @@
+# node plugin
+
+Add [oh-my-bash](https://ohmybash.github.io) integration for [Node.js](https://nodejs.org/) development, providing aliases and utilities for everyday Node.js workflows. Inspired by the [oh-my-zsh node plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/node).
+
+## Installation
+
+Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.bashrc`.
+
+```sh
+plugins=(node)
+```
+
+## Aliases
+
+| Alias          | Command          | Description                    |
+|----------------|------------------|--------------------------------|
+| `node-version` | `node --version` | Print the current Node version |
+
+## Functions
+
+### `node-docs [section]`
+
+Open the Node.js API documentation for the **currently active Node.js version** in a browser. Falls back to printing the URL if no browser opener is available.
+
+```bash
+node-docs         # open the full API index
+node-docs fs      # open the 'fs' module docs
+node-docs http    # open the 'http' module docs
+node-docs stream  # open the 'stream' module docs
+```
+
+Works with any Node.js version manager (nvm, mise, asdf, etc.) — it always reflects the version currently on your `$PATH`.
+
+### `node-json <expression>`
+
+Evaluate a JavaScript expression via `node -e` and pretty-print the result as JSON. Useful for quickly inspecting Node.js internals.
+
+```bash
+node-json 'process.versions'   # print all runtime versions
+node-json 'process.env'        # print environment variables
+node-json 'os.cpus().length'   # requires: const os = require("os")
+```

--- a/plugins/node/node.plugin.sh
+++ b/plugins/node/node.plugin.sh
@@ -1,0 +1,43 @@
+#! bash oh-my-bash.module
+# Description: Aliases and utilities for Node.js development
+# Inspired by the oh-my-zsh node plugin (https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/node)
+
+if ! _omb_util_command_exists node; then
+  return
+fi
+
+alias node-version='node --version'
+
+#------------------------------------------------------------------------------
+# Open the Node.js API documentation for the current version in a browser.
+# Usage: node-docs [section]
+# Examples:
+#   node-docs           # opens the full API index
+#   node-docs fs        # opens the 'fs' module page
+#   node-docs http      # opens the 'http' module page
+function node-docs {
+  local section=${1:-all}
+  local version
+  version=$(node --version)
+  local url="https://nodejs.org/docs/${version}/api/${section}.html"
+
+  if _omb_util_command_exists xdg-open; then
+    xdg-open "$url"
+  elif _omb_util_command_exists open; then
+    open "$url"
+  else
+    _omb_util_print "$url"
+  fi
+}
+
+#------------------------------------------------------------------------------
+# Print a Node.js-friendly JSON representation of an object via node -e.
+# Usage: node-json <expression>
+# Example: node-json 'process.versions'
+function node-json {
+  if [[ -z ${1-} ]]; then
+    _omb_util_print 'node-json: usage: node-json <expression>' >&2
+    return 1
+  fi
+  node -e "console.log(JSON.stringify($1, null, 2))"
+}

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -1,27 +1,70 @@
 # npm plugin
 
-The npm plugin provides completion as well as adding many useful aliases.
+Add [oh-my-bash](https://ohmybash.github.io) integration for [npm](https://www.npmjs.com/), providing aliases for common npm workflows. Inspired by the [oh-my-zsh npm plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/npm).
 
-To use it, add npm to the plugins array of your bashrc file:
+## Installation
 
-```bash
-plugins=(... npm)
+Enable the plugin by adding it to your oh-my-bash `plugins` definition in `~/.bashrc`.
+
+```sh
+plugins=(npm)
+```
+
+Optionally, enable npm tab completions:
+
+```sh
+completions=(npm)
 ```
 
 ## Aliases
 
-| Alias   | Command                      | Descripton                                                      |
-|:------  |:-----------------------------|:----------------------------------------------------------------|
-| `npmg`  | `npm i -g`                   | Install dependencies globally                                   |
-| `npmS`  | `npm i -S`                   | Install and save to dependencies in your package.json           |
-| `npmD`  | `npm i -D`                   | Install and save to dev-dependencies in your package.json       |
-| `npmE`  | `PATH="$(npm bin)":"$PATH"`  | Run command from node_modules folder based on current directory |
-| `npmO`  | `npm outdated`               | Check which npm modules are outdated                            |
-| `npmV`  | `npm -v`                     | Check package versions                                          |
-| `npmL`  | `npm list`                   | List installed packages                                         |
-| `npmL0` | `npm ls --depth=0`           | List top-level installed packages                               |
-| `npmst` | `npm start`                  | Run npm start                                                   |
-| `npmt`  | `npm test`                   | Run npm test                                                    |
-| `npmR`  | `npm run`                    | Run npm scripts                                                 |
-| `npmP`  | `npm publish`                | Run npm publish                                                 |
-| `npmI`  | `npm init`                   | Run npm init                                                    |
+### Install
+
+| Alias   | Command        | Description                                           |
+|---------|----------------|-------------------------------------------------------|
+| `npmg`  | `npm i -g`     | Install a package globally                            |
+| `npmS`  | `npm i -S`     | Install and save to `dependencies`                    |
+| `npmD`  | `npm i -D`     | Install and save to `devDependencies`                 |
+| `npmF`  | `npm i -f`     | Force-install, bypassing the cache                    |
+| `npmU`  | `npm update`   | Update all packages to their latest allowed versions  |
+
+### Init / Info / Search
+
+| Alias   | Command        | Description                         |
+|---------|----------------|-------------------------------------|
+| `npmI`  | `npm init`     | Initialise a new `package.json`     |
+| `npmi`  | `npm info`     | Show information about a package    |
+| `npmSe` | `npm search`   | Search the npm registry             |
+
+### Run scripts
+
+| Alias   | Command           | Description                    |
+|---------|-------------------|--------------------------------|
+| `npmst` | `npm start`       | Run the `start` script         |
+| `npmt`  | `npm test`        | Run the `test` script          |
+| `npmR`  | `npm run`         | Run an arbitrary script        |
+| `npmrd` | `npm run dev`     | Run the `dev` script           |
+| `npmrb` | `npm run build`   | Run the `build` script         |
+
+### Publish
+
+| Alias   | Command        | Description           |
+|---------|----------------|-----------------------|
+| `npmP`  | `npm publish`  | Publish the package   |
+
+### Inspect
+
+| Alias    | Command              | Description                               |
+|----------|----------------------|-------------------------------------------|
+| `npmO`   | `npm outdated`       | List outdated packages                    |
+| `npmV`   | `npm -v`             | Print the npm version                     |
+| `npmL`   | `npm list`           | List all installed packages               |
+| `npmL0`  | `npm ls --depth=0`   | List top-level installed packages only    |
+
+### Local binaries / npx
+
+| Alias   | Command                                          | Description                                  |
+|---------|--------------------------------------------------|----------------------------------------------|
+| `npmE`  | `PATH="$(npm prefix)/node_modules/.bin:$PATH"`   | Prepend local `node_modules/.bin` to `$PATH` |
+| `npmx`  | `npx`                                            | Shorthand for `npx`                          |
+

--- a/plugins/npm/npm.plugin.sh
+++ b/plugins/npm/npm.plugin.sh
@@ -2,8 +2,6 @@
 # Description: Aliases and utilities for npm
 # Inspired by the oh-my-zsh npm plugin (https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/npm)
 
-_omb_module_require completion:npm
-
 if ! _omb_util_command_exists npm; then
   return
 fi
@@ -40,5 +38,4 @@ alias npmL0="npm ls --depth=0"
 alias npmE='PATH="$(npm prefix)/node_modules/.bin:$PATH"'
 
 # npx shortcuts
-alias npx='npx'
 alias npmx='npx'

--- a/plugins/npm/npm.plugin.sh
+++ b/plugins/npm/npm.plugin.sh
@@ -1,45 +1,44 @@
 #! bash oh-my-bash.module
-# Install dependencies globally
-alias npmg="npm i -g "
+# Description: Aliases and utilities for npm
+# Inspired by the oh-my-zsh npm plugin (https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/npm)
 
-# npm package names are lowercase
-# Thus, we've used camelCase for the following aliases:
+_omb_module_require completion:npm
 
-# Install and save to dependencies in your package.json
-# npms is used by https://www.npmjs.com/package/npms
-alias npmS="npm i -S "
+if ! _omb_util_command_exists npm; then
+  return
+fi
 
-# Install and save to dev-dependencies in your package.json
-# npmd is used by https://github.com/dominictarr/npmd
-alias npmD="npm i -D "
+# Install
+alias npmg="npm i -g"
+alias npmS="npm i -S"
+alias npmD="npm i -D"
+alias npmF="npm i -f"
+alias npmU="npm update"
 
-# Execute command from node_modules folder based on current directory
-# i.e npmE gulp
-alias npmE='PATH="$(npm bin)":"$PATH"'
+# Init / Info / Search
+alias npmI="npm init"
+alias npmi="npm info"
+alias npmSe="npm search"
 
-# Check which npm modules are outdated
-alias npmO="npm outdated"
-
-# Check package versions
-alias npmV="npm -v"
-
-# List packages
-alias npmL="npm list"
-
-# List top-level installed packages
-alias npmL0="npm ls --depth=0"
-
-# Run npm start
+# Run scripts
 alias npmst="npm start"
-
-# Run npm test
 alias npmt="npm test"
-
-# Run npm scripts
 alias npmR="npm run"
+alias npmrd="npm run dev"
+alias npmrb="npm run build"
 
-# Run npm publish
+# Publish
 alias npmP="npm publish"
 
-# Run npm init
-alias npmI="npm init"
+# Inspect
+alias npmO="npm outdated"
+alias npmV="npm -v"
+alias npmL="npm list"
+alias npmL0="npm ls --depth=0"
+
+# Run a local binary from node_modules/.bin via npx
+alias npmE='PATH="$(npm prefix)/node_modules/.bin:$PATH"'
+
+# npx shortcuts
+alias npx='npx'
+alias npmx='npx'


### PR DESCRIPTION
**Node.js and npm plugin improvements:**

* Added a new `node` plugin with a README and plugin script, providing aliases (e.g., `node-version`) and utility functions (`node-docs` for browsing Node.js API docs by version and section, and `node-json` for pretty-printing JavaScript expressions as JSON). [[1]](diffhunk://#diff-f212c4f95925dd38329146ef5a92501ecdb1eedae302052e6586f27e1185eea1R1-R42) [[2]](diffhunk://#diff-aa113b393a1036b857ee6179fc1e3ee47e129ada643de384e029bccc4af15e48R1-R43)
* Updated the main plugins list in `README.md` to include and describe the new `node` plugin, and improved the `npm` plugin entry with links and clearer descriptions.

**npm plugin enhancements:**

* Rewrote the `npm` plugin README with clearer installation instructions, detailed alias tables grouped by theme (install, info, scripts, publish, inspect, binaries), and improved descriptions for each alias.
* Refactored and expanded `npm.plugin.sh` to add new aliases (e.g., `npmF`, `npmU`, `npmrd`, `npmrb`, `npmSe`, `npmx`), improve existing ones, and clarify their usage, aligning with the oh-my-zsh npm plugin.