### PR TITLE
Snapshot of a nix-shell environment indicator plugin.

### DIFF
--- a/plugins/nix/README.md
+++ b/plugins/nix/README.md
@@ -1,0 +1,5 @@
+# Nix Plugin
+
+A simple plugin for `nix-shell` and `nix develop`(flake) to indicate current environment through modifying the `PS1` in the `$PROMPT_COMMAND`
+
+### Currently experimental

--- a/plugins/nix/nix.plugin.sh
+++ b/plugins/nix/nix.plugin.sh
@@ -13,4 +13,10 @@ function _nix_indicator_update_prompt() {
 }
 
 # Append  to PROMPT_COMMAND 
-PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_nix_indicator_update_prompt"
+if [[ -z "$PROMPT_COMMAND" ]]; then # Cheking if PROMPT_COMMAND variable exists.
+    PROMPT_COMMAND="_nix_indicator_update_prompt"
+elif [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" =~ "declare -a" ]]; then # Cheking existing PROMPT_COMMAND if it is a string.
+    PROMPT_COMMAND+=(_nix_indicator_update_prompt)
+else
+    PROMPT_COMMAND="${PROMPT_COMMAND}; _nix_indicator_update_prompt"
+fi

--- a/plugins/nix/nix.plugin.sh
+++ b/plugins/nix/nix.plugin.sh
@@ -1,0 +1,16 @@
+#! bash oh-my-bash.module
+
+function _nix_indicator_update_prompt() {
+    if [[ -n "$IN_NIX_SHELL" ]]; then
+        local original_ps1="$PS1" # Stores a local backup of PS1 to recheck.
+        # Try \h (hostname) first
+        PS1="${PS1/\\h/nix-shell}"
+        # If unchanged, fallback to \u (username)
+        if [[ "$PS1" == "$original_ps1" ]]; then
+            PS1="${PS1/\\u/nix-shell}"
+        fi
+    fi
+}
+
+# Append  to PROMPT_COMMAND 
+PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }_nix_indicator_update_prompt"


### PR DESCRIPTION
Adds a plugin that changes the prompt to show `nix-shell` when inside a nix-shell or nix develop environment.

It works by appending to `$PROMPT_COMMAND` and replaces `\h` with `nix-shell` (or `\u` as fallback) when `$IN_NIX_SHELL` is set. Currently works with `axin`, `pure`, `clean`,  `bobby`, and almost every theme that uses `\h` or `\u` in it's `PS1`.