### PR TITLE
feat(tmux): add bash completion for session aliases

### DIFF
--- a/completions/terraform.completion.sh
+++ b/completions/terraform.completion.sh
@@ -26,11 +26,11 @@ _terraform()
 complete -F _terraform terraform
 
 function _omb_terraform_alias_complete() {
-  local cur=${COMP_WORDS[COMP_CWORD]}
-  local prev=""
-  if ((COMP_CWORD > 0)); then
-    prev=${COMP_WORDS[COMP_CWORD - 1]}
+  if ((COMP_CWORD == 0)); then
+    return 1
   fi
+
+  local cur=${COMP_WORDS[COMP_CWORD]}
   local cmd=${COMP_WORDS[0]}
 
   local expansion
@@ -136,7 +136,7 @@ function _omb_terraform_alias_complete() {
       real_func="${real_func%\"}"
     fi
 
-    if [[ $real_func ]]; then
+    if [[ $real_func ]] && _omb_util_function_exists "$real_func"; then
       local -a COMP_WORDS_saved=("${COMP_WORDS[@]}")
       local COMP_CWORD_saved=$COMP_CWORD
       local COMP_LINE_saved="$COMP_LINE"

--- a/completions/terraform.completion.sh
+++ b/completions/terraform.completion.sh
@@ -24,3 +24,158 @@ _terraform()
         return 0
 } &&
 complete -F _terraform terraform
+
+function _omb_terraform_alias_complete() {
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local prev=""
+  if ((COMP_CWORD > 0)); then
+    prev=${COMP_WORDS[COMP_CWORD - 1]}
+  fi
+  local cmd=${COMP_WORDS[0]}
+
+  local expansion
+  case $cmd in
+    t)      expansion="terraform" ;;
+    tapply) expansion="terraform apply" ;;
+    tfmt)   expansion="terraform fmt" ;;
+    tinit)  expansion="terraform init" ;;
+    tplan)  expansion="terraform plan" ;;
+    *)      return 1 ;;
+  esac
+
+  local -a expansion_words=($expansion)
+  local -a new_words=("${expansion_words[@]}" "${COMP_WORDS[@]:1}")
+  local new_cword=$((COMP_CWORD + ${#expansion_words[@]} - 1))
+
+  local subcommand=""
+  case $cmd in
+    t)
+      if ((new_cword > 1)); then
+        subcommand="${new_words[1]}"
+      fi
+      ;;
+    tapply) subcommand="apply" ;;
+    tfmt)   subcommand="fmt" ;;
+    tinit)  subcommand="init" ;;
+    tplan)  subcommand="plan" ;;
+  esac
+
+  if [[ $cur == -* && $subcommand ]]; then
+    local flags=""
+    case $subcommand in
+      apply)
+        flags="-auto-approve -backup -compact-warnings -input -lock -lock-timeout -no-color -parallelism -state -state-out -target -var -var-file"
+        ;;
+      plan)
+        flags="-compact-warnings -destroy -detailed-exitcode -input -lock -lock-timeout -no-color -out -parallelism -state -target -var -var-file"
+        ;;
+      init)
+        flags="-backend -backend-config -force-copy -get -get-plugins -input -lock -lock-timeout -no-color -plugin-dir -reconfigure -upgrade"
+        ;;
+      fmt)
+        flags="-list -write -diff -check -recursive"
+        ;;
+    esac
+
+    if [[ $flags ]]; then
+      COMPREPLY=( $(compgen -W "$flags" -- "$cur") )
+      return 0
+    fi
+  fi
+
+  local leading_whitespace=""
+  local rest_of_line=""
+  if [[ $COMP_LINE =~ ^([[:space:]]*)([^[:space:]]+)(.*)$ ]]; then
+    leading_whitespace="${BASH_REMATCH[1]}"
+    rest_of_line="${BASH_REMATCH[3]}"
+  fi
+
+  local new_line="${leading_whitespace}${expansion}${rest_of_line}"
+  local new_point=$((COMP_POINT + ${#expansion} - ${#cmd}))
+
+  local completion_info
+  completion_info=$(complete -p terraform 2>/dev/null)
+
+  if [[ $completion_info == *"-C "* ]]; then
+    local real_cmd=""
+    if [[ $completion_info =~ -C[[:space:]]+(\'[^\']+\'|\"[^\"]+\"|[^[:space:]]+) ]]; then
+      real_cmd="${BASH_REMATCH[1]}"
+      real_cmd="${real_cmd#\'}"
+      real_cmd="${real_cmd%\'}"
+      real_cmd="${real_cmd#\"}"
+      real_cmd="${real_cmd%\"}"
+    fi
+
+    if [[ $real_cmd ]]; then
+      local new_cur="${new_words[new_cword]}"
+      local new_prev=""
+      if ((new_cword > 0)); then
+        new_prev="${new_words[new_cword - 1]}"
+      fi
+
+      local -a results
+      _omb_util_split_lines results "$(COMP_LINE="$new_line" COMP_POINT="$new_point" "$real_cmd" "terraform" "$new_cur" "$new_prev" 2>/dev/null)"
+
+      COMPREPLY=()
+      local r escaped
+      for r in "${results[@]}"; do
+        printf -v escaped '%q' "$r"
+        COMPREPLY+=("$escaped")
+      done
+      return 0
+    fi
+  fi
+
+  if [[ $completion_info == *"-F "* ]]; then
+    local real_func=""
+    if [[ $completion_info =~ -F[[:space:]]+(\'[^\']+\'|\"[^\"]+\"|[^[:space:]]+) ]]; then
+      real_func="${BASH_REMATCH[1]}"
+      real_func="${real_func#\'}"
+      real_func="${real_func%\'}"
+      real_func="${real_func#\"}"
+      real_func="${real_func%\"}"
+    fi
+
+    if [[ $real_func ]]; then
+      local -a COMP_WORDS_saved=("${COMP_WORDS[@]}")
+      local COMP_CWORD_saved=$COMP_CWORD
+      local COMP_LINE_saved="$COMP_LINE"
+      local COMP_POINT_saved=$COMP_POINT
+
+      COMP_WORDS=("${new_words[@]}")
+      COMP_CWORD=$new_cword
+      COMP_LINE="$new_line"
+      COMP_POINT=$new_point
+
+      "$real_func"
+
+      COMP_WORDS=("${COMP_WORDS_saved[@]}")
+      COMP_CWORD=$COMP_CWORD_saved
+      COMP_LINE="$COMP_LINE_saved"
+      COMP_POINT=$COMP_POINT_saved
+      return 0
+    fi
+  fi
+
+  if _omb_util_function_exists _terraform; then
+    local -a COMP_WORDS_saved=("${COMP_WORDS[@]}")
+    local COMP_CWORD_saved=$COMP_CWORD
+    local COMP_LINE_saved="$COMP_LINE"
+    local COMP_POINT_saved=$COMP_POINT
+
+    COMP_WORDS=("${new_words[@]}")
+    COMP_CWORD=$new_cword
+    COMP_LINE="$new_line"
+    COMP_POINT=$new_point
+
+    _terraform
+
+    COMP_WORDS=("${COMP_WORDS_saved[@]}")
+    COMP_CWORD=$COMP_CWORD_saved
+    COMP_LINE="$COMP_LINE_saved"
+    COMP_POINT=$COMP_POINT_saved
+    return 0
+  fi
+}
+
+complete -F _omb_terraform_alias_complete t tapply tfmt tinit tplan

--- a/custom/claude_helpers.sh
+++ b/custom/claude_helpers.sh
@@ -1,0 +1,130 @@
+claude_at() {
+    local session_name="$1"
+    # Accept variable time arguments (everything after the first arg)
+    local run_time="${*:2}"
+    local current_tty
+
+    # Help menu check
+    if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+        echo "Usage: claude_at <tmux_session> <time>"
+        echo ""
+        echo "Schedules a non-interactive resume command into a running tmux session at a specific time using 'at'."
+        echo ""
+        echo "Arguments:"
+        echo "  <tmux_session>  Name of the target active tmux session (e.g., interleaf)"
+        echo "  <time>          Execution time. May contain multiple words for 'at' (e.g., '5:01 PM' or 'now + 2 minutes')"
+        echo ""
+        echo "Examples:"
+        echo "  claude_at my_tmux_session_name 12:01"
+        echo "  claude_at my_tmux_session_name 5:01 PM"
+        echo "  claude_at my_tmux_session_name now + 2 minutes"
+        return 0
+    fi
+
+    # Validation check for missing arguments
+    if [[ -z "$session_name" || -z "$run_time" ]]; then
+        echo "Error: Missing arguments."
+        echo "Try 'claude_at --help' for more information."
+        return 1
+    fi
+
+    current_tty=$(tty)
+
+    # Try to compute the effective scheduled time as a full ISO 8601 timestamp.
+    # date -d accepts many of the same formats as at; if it fails, leave blank.
+    local effective_time_create
+    effective_time_create=$(date -d "$run_time" --iso-8601=seconds 2>/dev/null || true)
+
+    # Build the script that will be run by 'at'.
+    # Keep the $(date -Iseconds) literal so it's evaluated when the job runs.
+    at_script=$(cat <<AT_SCRIPT
+/usr/bin/tmux send-keys -t ${session_name} "claude --continue --dangerously-skip-permissions" Enter
+logger -t claude_at "Executed at job: input_time='${run_time}' effective_time='\$(date -Iseconds)' session='${session_name}'"
+/bin/echo "[at job] Claude session resumed in tmux." > ${current_tty}
+AT_SCRIPT
+)
+
+    # Schedule the at job and capture the at command output (job number / scheduling info).
+    job_info=$(printf "%s" "$at_script" | at "$run_time" 2>&1)
+    at_exit_code=$?
+
+    if [[ $at_exit_code -ne 0 ]]; then
+        echo "Failed to schedule at job: $job_info"
+        logger -t claude_at "Failed to schedule at job: input_time='${run_time}' session='${session_name}' error='${job_info//$'\n'/ }'"
+        return $at_exit_code
+    fi
+
+    # Log to the system logger that the at job was created, including both the input time and the effective ISO time.
+    # Include the raw output from at for traceability.
+    # Normalize newlines in job_info for a single-line log entry.
+    job_info_single_line=$(printf "%s" "$job_info" | tr '\n' ' ')
+    logger -t claude_at "Scheduled at job: input_time='${run_time}' effective_time='${effective_time_create}' session='${session_name}' at_output='${job_info_single_line}'"
+
+    # Also echo a user-facing confirmation to the current tty.
+    echo "Scheduled claude resume for session '${session_name}' at '${run_time}'."
+
+    return 0
+}
+
+_omb_plugin_tmux_directory_session_name() {
+    # Shared logic with oh-my-bash tds plugin to derive the tmux session name.
+    # Returns the session name in the format: <directory>-<6char-md5-hash>
+    local dir=${PWD##*/}
+    local md5
+    if _omb_util_command_exists md5sum; then
+        md5=$(printf '%s' "$PWD" | md5sum | cut -d ' ' -f 1)
+    elif _omb_util_command_exists md5; then
+        md5=$(printf '%s' "$PWD" | md5)
+    else
+        echo "[oh-my-bash] claude_at_tds: md5sum or md5 not found, tds requires one of them" >&2
+        return 1
+    fi
+    echo "${dir}-${md5:0:6}"
+}
+
+claude_at_tds() {
+    # Accept variable time arguments (everything after the first arg)
+    local run_time="${*:1}"
+    local session_name
+
+    # Help menu check
+    if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+        echo "Usage: claude_at_tds <time>"
+        echo ""
+        echo "Schedules a non-interactive claude resume for the current directory's tmux session at a specific time."
+        echo "Automatically detects the tmux session name from the current working directory (using oh-my-bash tds convention)."
+        echo ""
+        echo "Arguments:"
+        echo "  <time>  Execution time. May contain multiple words for 'at' (e.g., '5:01 PM' or 'now + 2 minutes')"
+        echo ""
+        echo "Examples:"
+        echo "  claude_at_tds 12:01"
+        echo "  claude_at_tds 5:01 PM"
+        echo "  claude_at_tds now + 2 minutes"
+        return 0
+    fi
+
+    # Validation check for missing arguments
+    if [[ -z "$run_time" ]]; then
+        echo "Error: Missing time argument."
+        echo "Try 'claude_at_tds --help' for more information."
+        return 1
+    fi
+
+    # Derive the session name using the same logic as oh-my-bash tds
+    session_name=$(_omb_plugin_tmux_directory_session_name)
+    if [[ $? -ne 0 ]]; then
+        return 1
+    fi
+
+    # Check if the session exists in tmux
+    if ! tmux has-session -t "$session_name" 2>/dev/null; then
+        echo "Error: Tmux session '$session_name' not found."
+        echo "Current directory: $(pwd)"
+        echo "To create a session using tds, run: tds"
+        return 1
+    fi
+
+    # Call claude_at with the detected session and provided time
+    claude_at "$session_name" $run_time
+}

--- a/plugins/tmux/tmux.plugin.bash
+++ b/plugins/tmux/tmux.plugin.bash
@@ -49,9 +49,18 @@ alias tds='_omb_plugin_tmux_directory_session'
 
 # Autocomplete for tmux aliases (ta, tad, tkss)
 function _omb_tmux_alias_sessions() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  local sessions=$(tmux list-sessions -F "#S" 2>/dev/null)
-  COMPREPLY=( $(compgen -W "${sessions}" -- "${cur}") )
+  local cur=${COMP_WORDS[COMP_CWORD]}
+
+  local -a sessions
+  _omb_util_split_lines sessions "$(tmux list-sessions -F '#S' 2>/dev/null)"
+
+  COMPREPLY=()
+  local s escaped
+  for s in "${sessions[@]}"; do
+    [[ $s == "$cur"* ]] || continue
+    printf -v escaped '%q' "$s"  # escapes spaces/glob metachars
+    COMPREPLY+=("$escaped")
+  done
 }
 
 complete -F _omb_tmux_alias_sessions ta tad tkss

--- a/plugins/tmux/tmux.plugin.bash
+++ b/plugins/tmux/tmux.plugin.bash
@@ -46,3 +46,12 @@ function _omb_plugin_tmux_directory_session {
 }
 
 alias tds='_omb_plugin_tmux_directory_session'
+
+# Autocomplete for tmux aliases (ta, tad, tkss)
+function _omb_tmux_alias_sessions() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local sessions=$(tmux list-sessions -F "#S" 2>/dev/null)
+  COMPREPLY=( $(compgen -W "${sessions}" -- "${cur}") )
+}
+
+complete -F _omb_tmux_alias_sessions ta tad tkss


### PR DESCRIPTION
Add bash autocomplete support for the `ta`, `tad`, and `tkss` aliases in the tmux plugin. This allows users to press tab to autocomplete active tmux session names when using these aliases.