### PR TITLE
fix(plugins/donottrack): disable opentelemetry sdk tracking

### DIFF
--- a/plugins/donottrack/donottrack.plugin.sh
+++ b/plugins/donottrack/donottrack.plugin.sh
@@ -65,6 +65,7 @@ _omb_plugin_donottrack_set MEILI_NO_ANALYTICS true
 _omb_plugin_donottrack_set MELTANO_DISABLE_TRACKING True
 _omb_plugin_donottrack_set MSSQL_CLI_TELEMETRY_OPTOUT True
 _omb_plugin_donottrack_set RASA_TELEMETRY_ENABLED false
+_omb_plugin_donottrack_set OTEL_SDK_DISABLED true
 
 # Misc
 _omb_plugin_donottrack_set CHEF_TELEMETRY_OPT_OUT 1


### PR DESCRIPTION
The OpenTelemetry SDK has an environment variable we can add: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/

```
OTEL_SDK_DISABLED
```